### PR TITLE
Enforce UTF-8 in meta tag to avoid character set problems

### DIFF
--- a/source/_includes/head.haml
+++ b/source/_includes/head.haml
@@ -1,5 +1,6 @@
 %head
   %title #{page.blog_title} :: #{page.title}
+  %meta(http-equiv="Content-Type" content="text/html; charset=utf-8")
   - if page.respond_to? :description
     %meta(name="description" content="#{page.description}")/
   - if page.respond_to? :keywords


### PR DESCRIPTION
I had problems with Swedish characters showing up as garbage when running "rake preview", so I added a meta tag to enforce UTF-8.
