### PR TITLE
Import the "base" SCSS file first, so the overwrites in _colors.scss work

### DIFF
--- a/.themes/classic/sass/screen.scss
+++ b/.themes/classic/sass/screen.scss
@@ -2,8 +2,8 @@
 @include global-reset;
 @include reset-html5;
 
+@import "base";
 @import "custom/colors";
 @import "custom/layout";
-@import "base";
 @import "partials";
 @import "custom/styles";


### PR DESCRIPTION
I hade to move the import of "base" to the start of the imports. Otherwise the switch from to the light Soalized theme as described in _colos.scss wouldn't work, since the variables weren't defined yet.
