### PR TITLE
Contain the rvm to a gemset

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm 1.9.2
+rvm 1.9.2@octopress --create


### PR DESCRIPTION
Contain the rvm to a [gemset](http://beginrescueend.com/gemsets/) so that it doesn't pollute 1.9.2? Agreeably could mess people doing an upstream update but would be a good default to use going forward.
