### PR TITLE
deploying to github pages resulted in a 'public' dir with all the files in it

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -163,7 +163,7 @@ desc "deploy public directory to github pages"
 task :push do
   puts "## Deploying branch to Github Pages "
   (Dir["#{deploy_dir}/*"]).each { |f| rm_rf(f) }
-  system "cp -R #{public_dir}/ #{deploy_dir}"
+  system "cp -R #{public_dir}/* #{deploy_dir}"
   puts "\n## copying #{public_dir} to #{deploy_dir}"
   cd "#{deploy_dir}" do
     system "git add ."


### PR DESCRIPTION
I noticed on my local filesystem in the _deploy there was also a 'public' dir with all the stuff in it.

Went to look what was the cause, and this fixed it.
