### PR TITLE
Edited .themes/classic/source/_includes/head.html via GitHub

### DIFF
--- a/.themes/classic/source/_includes/head.html
+++ b/.themes/classic/source/_includes/head.html
@@ -24,9 +24,16 @@
   <script src="{{ root_url }}/javascripts/modernizr-2.0.js"></script>
   <script src="http://s3.amazonaws.com/ender-js/jeesh.min.js"></script>
   <script src="{{ root_url }}/javascripts/octopress.js" type="text/javascript"></script>
-  <link href='http://fonts.googleapis.com/css?family=PT+Serif:regular,italic,bold,bolditalic' rel='stylesheet' type='text/css'>
-  <link href='http://fonts.googleapis.com/css?family=PT+Sans:regular,italic,bold,bolditalic' rel='stylesheet' type='text/css'>
-  <link href="{{ root_url }}/atom.xml" rel="alternate" title="{{site.title}}" type="application/atom+xml"/>
+  
+  <link href="http://fonts.googleapis.com/css?family=PT+Serif:regular,italic,bold,bolditalic" rel="stylesheet" type="text/css">
+  <link href="http://fonts.googleapis.com/css?family=PT+Sans:regular,italic,bold,bolditalic" rel="stylesheet" type="text/css">
+
+  {% if site.subscribe_rss == 'atom.xml' %}
+    <link href="{{ root_url }}/atom.xml" rel="alternate" title="{{site.title}}" type="application/atom+xml"/>
+  {% else %}
+    <link href="{{ site.subscribe_rss }}" rel="alternate" title="{{site.title}}" type="application/atom+xml"/>
+  {% endif %}
+
   {% include google_analytics.html %}
   {% include google_plus_one.html %}
   {% include twitter_sharing.html %}


### PR DESCRIPTION
The default for site.subscribe_rss is atom.xml

But if this is changed to a feedburner URL, the head is not updated with that link.

I have proposed a fix, but I don't think it is as elegant as it could be.

The other two lines, CSS files from Google Fonts, I changed the single quotes on the attributes to double quotes, for consistency.
