### PR TITLE
Code blocks didn't work with textile

### DIFF
--- a/plugins/code_block.rb
+++ b/plugins/code_block.rb
@@ -75,6 +75,7 @@ module Jekyll
       code = super.join
       source = "<div><figure role=code>"
       source += @caption if @caption
+      source = context['pygments_prefix'] + source if context['pygments_prefix']
       if @filetype
         @filetype = 'objc' if @filetype == 'm'
         @filetype = 'perl' if @filetype == 'pl'
@@ -82,6 +83,7 @@ module Jekyll
       else
         source += "<pre><code>" + code.lstrip.rstrip.gsub(/</,'&lt;') + "</code></pre></figure></div>"
       end
+      source = source + context['pygments_suffix'] if context['pygments_suffix']
       partial = Liquid::Template.parse(source)
       context.stack do
         partial.render(context)


### PR DESCRIPTION
To make code blocks work with textile I needed to add the tags `<notextile>` and `</notextile>` to the Pygments block. I did this the same way standard Jekyll does it ([see the two lines here](https://github.com/mojombo/jekyll/blob/master/lib/jekyll/tags/highlight.rb#L47-48)).

I tried to make it work with the new Github style code blocks, too, but wasn't too successful. It seems the filters there are too late in the process, and textile has already tried to parse the code, so it wouldn't be that easy.
