### PR TITLE
added source.old and sass.old into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ _gist_cache
 _code_cache
 _deploy
 public
+sass.old
+source.old
 source/_stash
 source/stylesheets/screen.css
 vendor


### PR DESCRIPTION
since source.old and sass.old are created through the update rake tasks, I don't see a reason for them to be tracked through git.
