### PR TITLE
Clarify need for 'source' branch

### DIFF
--- a/source/docs/setup/index.markdown
+++ b/source/docs/setup/index.markdown
@@ -27,6 +27,13 @@ Next, if you're using Github pages for users or organizations, create a source b
     git push origin source
 ```
 
+The `source` branch is created to have somewhere to store the source
+of your site. GitHub expects the generated site to be pushed to the
+`master` branch of your GitHub repository so that branch needs to stay
+clean. As we will see later, in the [Deploying Octopress](/docs/deploying/)
+section, a "link" to the `master` branch will be created in the
+`_deploy` directory in which the generated site will end up.
+
 Next, setup an [RVM](http://beginrescueend.com/) and install dependencies.
 
 ``` sh


### PR DESCRIPTION
When first playing around with Octopress I was a bit confused as to why one needs to check out first the `master` branch, then create `source`, and later checkout `master` again in the `_deploy` directory. I finally understood that the purpose of the `source` branch is to keep the source of the site (duh!) and for `master` to be the location of the generated site (which GitHub will pick up). I added a text about this in the Setup documentation page for Octopress.
