### PR TITLE
correctly scope locals

### DIFF
--- a/.themes/classic/source/javascripts/twitter.js
+++ b/.themes/classic/source/javascripts/twitter.js
@@ -1,13 +1,15 @@
 // JSON-P Twitter fetcher for Octopress
 // (c) Brandon Mathis // MIT Lisence
 function getTwitterFeed(user, count, replies) {
-  feed = new jXHR();
+  var feed = new jXHR();
+
   feed.onerror = function (msg,url) {
     $('#tweets li.loading').addClass('error').text("Twitter's busted");
   }
   feed.onreadystatechange = function(data){
     if (feed.readyState === 4) {
       var tweets = new Array();
+      var i = 0;
       for (i in data){
         if(tweets.length < count){
           if(replies || data[i].in_reply_to_user_id == null){


### PR DESCRIPTION
While looking into implementing a plugin to list github repositories, I was going through the existing plugins and noticed that the twitter plugin is introducing two very commonly named global variables: feed and i.

As these aren't used by the twitter plugin outside the enclosing scope, I would recommend making them local variables.

This pull request does just that.
