### PR TITLE
Custom plugins

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,6 +33,7 @@ task :install, :theme do |t, args|
   cp_r "#{themes_dir}/#{theme}/sass/.", "sass"
   mkdir_p "#{source_dir}/#{posts_dir}"
   mkdir_p public_dir
+  mkdir_p "#{source_dir}/plugins"
 end
 
 #######################

--- a/plugins/custom_plugins.rb
+++ b/plugins/custom_plugins.rb
@@ -1,0 +1,3 @@
+Dir[File.expand_path(File.dirname(__FILE__) + '/../source/plugins/**/*.rb')].each do |plugin|
+  require plugin
+end


### PR DESCRIPTION
I had the need to extend jekyll and needed a place to stick my code. I didn't want to pollute the `./plugins` folder, so I created a way for people to stick their own plugins in `./source/plugins` and have those be automatically loaded by jekyll.

You'll notice that all this does is require any ruby file in `./source/plugins`. This appears to be the only way to accomplish this since jekyll doesn't allow for loading plugins from multiple directories.
