### PR TITLE
minor tweak to _typography.scss to have pp, code, and tt extend style that exists

### DIFF
--- a/.themes/classic/sass/base/_typography.scss
+++ b/.themes/classic/sass/base/_typography.scss
@@ -86,7 +86,7 @@ del, s { text-decoration: line-through; }
 
 abbr, acronym { border-bottom: 1px dotted; cursor: help; }
 
-pre, code, tt { @extend .mono-font; }
+pre, code, tt { @extend .mono; }
 
 sub, sup { line-height: 0; }
 


### PR DESCRIPTION
fixed @extend for pp, code, and tt. The @extend was extending a non-existant entry (.mono-font). Changed to have them extend .mono.
