### PR TITLE
fix rake-list

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -256,6 +256,6 @@ end
 
 desc "list tasks"
 task :list do
-  puts "Tasks: #{(Rake::Task.tasks - [Rake::Task[:list]]).to_sentence}"
+  puts "Tasks: #{(Rake::Task.tasks - [Rake::Task[:list]]).join(', ')}"
   puts "(type rake -T for more detail)\n\n"
 end


### PR DESCRIPTION
`rake list` was not work because "to_sentence" method missing.
Is it comes from ActiveSupport and deprecated from version 3.0.0? (I'm not sure.)
