### PR TITLE
optional: show comment count on blog index

### DIFF
--- a/.themes/classic/source/_includes/article.html
+++ b/.themes/classic/source/_includes/article.html
@@ -13,7 +13,7 @@
 {% if index %}
   <div class="entry-content">{{ content | excerpt }}</div>
   <footer>
-    <a rel="full-article" href="{{ root_url }}{{ post.url }}">Read on &rarr;</a>
+  <a rel="full-article" href="{{ root_url }}{{ post.url }}{% if site.disqus_show_comment_count %}#disqus_thread{% endif %}">Read on &rarr;</a>
   </footer>
 {% else %}
 <div class="entry-content">{{ content }}</div>

--- a/.themes/classic/source/_includes/blog_index.html
+++ b/.themes/classic/source/_includes/blog_index.html
@@ -19,7 +19,7 @@
     {% endif %}
   </div>
 </nav>
-{% if site.disqus_short_name %}
+{% if site.disqus_short_name and disqus_show_comment_count %}
 <script type="text/javascript">
     var disqus_shortname = '{{ site.disqus_short_name }}';
     (function () {

--- a/_config.yml
+++ b/_config.yml
@@ -69,6 +69,7 @@ delicious_count: 3
 
 # Disqus Comments
 disqus_short_name:
+disqus_show_comment_count: false
 
 # Google Analytics
 google_analytics_tracking_id:


### PR DESCRIPTION
Hi,

this pull request generates a configuration file entry 

disqus_show_comment_count

if set to true, disqus will show the comment count (and/or reaction count - that's configurable on the diqus admin pages) on the blog index.

IMHO, it was an oversight that this wasn't shown earlier as the disqus JS for counting was already integrated, but the read-more links were missing the #disqus_thread anchor. Now, if this new config setting is set to false, the disqus script won't be sourced on the index page any more as providing the comment count is the only thing it would do. If that's not desired, then the script doesn't need to be loaded.

You can see this in action on the main page of my blog (http://pilif.github.com) which has a "x Comments and y Reactions" link instead of the "Read on"-Link.

I hope you find this useful.

Philip
