### PR TITLE
Fix extra subdirectories appearing in category links and atom.xml link.

### DIFF
--- a/.themes/classic/source/_includes/head.html
+++ b/.themes/classic/source/_includes/head.html
@@ -25,8 +25,7 @@
   <script src="{{ root_url }}/javascripts/modernizr-2.0.js"></script>
   <script src="http://s3.amazonaws.com/ender-js/jeesh.min.js"></script>
   <script src="{{ root_url }}/javascripts/octopress.js" type="text/javascript"></script>
-  {% capture rss_url %}{% if site.subscribe_rss contains ':' %}{{ site.subscribe_rss }}{% else %}{{ root_url }}{{ site.subscribe_rss }}{% endif %}{% endcapture %}
-  <link href="{{ rss_url }}" rel="alternate" title="{{site.title}}" type="application/atom+xml"/>
+  <link href="{{ site.subscribe_rss }}" rel="alternate" title="{{site.title}}" type="application/atom+xml"/>
   {% include google_analytics.html %}
   {% include google_plus_one.html %}
   {% include twitter_sharing.html %}

--- a/plugins/category_generator.rb
+++ b/plugins/category_generator.rb
@@ -104,9 +104,8 @@ module Jekyll
     #
     def category_links(categories)
       dir = @context.registers[:site].config['category_dir']
-      root_url = @context.registers[:site].config['root'].sub(/\/$/, '')
       categories = categories.sort!.map do |item|
-        "<a class='category' href='#{root_url}/#{dir}/#{item.gsub(/_|\W/, '-')}/'>#{item}</a>"
+        "<a class='category' href='/#{dir}/#{item.gsub(/_|\W/, '-')}/'>#{item}</a>"
       end
 
       case categories.length


### PR DESCRIPTION
I found a couple of places where the subdirectory was being duplicated in links.
1. In head.xml, if there was no colon in site.subscribe_rss, it was being appended to root_url. However, the rake set_root_dir script already includes root_url in subscribe_rss, so I removed the extra root_url. This left no difference between colon and no colon, so I also removed the if condition.
2. In category_generator.rb:category_links, the root_url was being prepended to the category links, but the expand_urls filter in default.html is already handling that, so I removed the reference to root_url when generating category links.
