### PR TITLE
Fix Code Text in Lists

### DIFF
--- a/.themes/classic/sass/partials/_syntax.scss
+++ b/.themes/classic/sass/partials/_syntax.scss
@@ -85,7 +85,8 @@ h3.filename {
   + pre { @include border-top-radius(0px); }
 }
 
-p code {
+p code,
+li code {
   @extend .mono;
   display: inline-block;
   white-space: no-wrap;


### PR DESCRIPTION
This enables `code` text to display properly in lists.
