### PR TITLE
Remove system specific file I/O from Rakefile 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -50,12 +50,42 @@ end
 
 desc "Watch the site and regenerate when it changes"
 task :watch do
-  system "trap 'kill $jekyllPid $compassPid' Exit; jekyll --auto & jekyllPid=$!; compass watch & compassPid=$!; wait"
+require 'compass'
+require 'compass/exec'
+  puts "Starting to watch source with Jekyll and Compass."
+  jekyllPid = spawn("jekyll --auto")
+  compassPid = spawn("compass watch")
+  
+  trap("INT") { 
+	Process.kill(9, jekyllPid)
+	Process.kill(9, compassPid)
+	puts "Waiting for Jekyll and Compass to die."
+	sleep 5
+	puts "Done waiting. Bye bye."
+	exit 0
+  }
+  
+  Process.wait
 end
 
 desc "preview the site in a web browser"
 task :preview do
-  system "trap 'kill $jekyllPid $compassPid $rackPid' Exit; jekyll --auto & jekyllPid=$!; compass watch & compassPid=$!; rackup --port #{server_port} & rackPid=$!; wait"
+  puts "Starting to watch source with Jekyll and Compass. Starting Rack on port #{server_port}"
+  jekyllPid = spawn("jekyll --auto")
+  compassPid = spawn("compass watch")
+  rackupPid = spawn("rackup --port #{server_port}")  
+  
+  trap("INT") { 
+	Process.kill(9, jekyllPid)
+	Process.kill(9, compassPid)
+	Process.kill(9, rackupPid)
+	puts "Waiting for Jekyll, Compass and Rack to die."
+	sleep 10
+	puts "Done waiting. Bye bye."
+	exit 0
+  }
+  
+  Process.wait
 end
 
 # usage rake new_post[my-new-post] or rake new_post['my new post'] or rake new_post (defaults to "new-post")


### PR DESCRIPTION
This is in relation to an issue I opened #110, then thought hey I could fix that. So, after asking a few friends where to look for Ruby docs and what not, I found FileUtils, I also realized that you had been using it already. I went ahead and translated all of the (system "cp", "mv", "rm", "mkdir") calls to their respective FileUtils corresponding method. It didn't seem to have a force flag for copy but other than that everything should have been translated properly. 
