### PR TITLE
Static Server based on Sinatra (Heroku Support)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,17 @@
 source "http://rubygems.org"
 
-gem 'rake'
-gem 'rack'
-gem 'jekyll'
-gem 'rdiscount'
-gem 'pygments.rb'
-gem 'RedCloth'
-gem 'haml', '>= 3.1'
-gem 'compass', '>= 0.11'
-gem 'rubypants'
-gem 'rb-fsevent'
-gem 'stringex'
+group :development do 
+  gem 'rake'
+  gem 'rack'
+  gem 'jekyll'
+  gem 'rdiscount'
+  gem 'pygments.rb'
+  gem 'RedCloth'
+  gem 'haml', '>= 3.1'
+  gem 'compass', '>= 0.11'
+  gem 'rubypants'
+  gem 'rb-fsevent'
+  gem 'stringex'
+end
+
+gem 'sinatra', '1.2.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,8 +40,12 @@ GEM
       blankslate (>= 2.1.2.3)
       ffi (~> 1.0.7)
     sass (3.1.5)
+    sinatra (1.2.6)
+      rack (~> 1.1)
+      tilt (>= 1.2.2, < 2.0)
     stringex (1.3.0)
     syntax (1.0.0)
+    tilt (1.3.2)
 
 PLATFORMS
   ruby
@@ -57,4 +61,5 @@ DEPENDENCIES
   rb-fsevent
   rdiscount
   rubypants
+  sinatra (= 1.2.6)
   stringex

--- a/config.ru
+++ b/config.ru
@@ -1,35 +1,25 @@
-require 'rubygems'
 require 'bundler/setup'
-require 'rack'
+require 'sinatra/base'
 
 # The project root directory
 $root = ::File.dirname(__FILE__)
 
-# Common Rack Middleware
-use Rack::ShowStatus      # Nice looking 404s and other messages
-use Rack::ShowExceptions  # Nice looking errors
+class SinatraStaticServer < Sinatra::Base  
 
-#
-# From Rack::DirectoryIndex:
-# https://github.com/craigmarksmith/rack-directory-index/
-#
-module Rack
-  class DirectoryIndex
-    def initialize(app)
-      @app = app
-    end
-    def call(env)
-      index_path = ::File.join($root, 'public', Rack::Request.new(env).path.split('/'), 'index.html')
-      if ::File.exists?(index_path)
-        return [200, {"Content-Type" => "text/html"}, [::File.read(index_path)]]
-      else
-        @app.call(env)
-      end
-    end
+  get(/.+/) do
+    send_sinatra_file(request.path) {404}
   end
+
+  not_found do
+    send_sinatra_file('404.html') {"Sorry, I cannot find #{request.path}"}
+  end
+
+  def send_sinatra_file(path, &missing_file_block)
+    file_path = File.join(File.dirname(__FILE__), 'public',  path)
+    file_path = File.join(file_path, 'index.html') unless file_path =~ /\.[a-z]+$/i  
+    File.exist?(file_path) ? send_file(file_path) : missing_file_block.call
+  end
+
 end
 
-use Rack::DirectoryIndex
-
-run Rack::Directory.new($root + '/public')
-
+run SinatraStaticServer


### PR DESCRIPTION
This change was made to better enable Octopress to run on Heroku (or any other rack based host). 

The default Octopress server is a great for local previews, but in production I feel things like proper mime/content types, last modified headers, etc are very important. 

All of this could have been done by adding more code to the built in server, but to me a much easier approach is to simply use Sinatra which has all of this and more built in. 

In addition, this enables for proper 404's and potentially allows users to add other dynamic features in the future. 

Two big changes: 
- Sinatra based server 
- updated the Gemfile to exclude most gem outside of development (default).
