### PR TITLE
Fixes issue 126, broken line height on "diff" syntax highlighting

### DIFF
--- a/.themes/classic/sass/partials/_syntax.scss
+++ b/.themes/classic/sass/partials/_syntax.scss
@@ -177,7 +177,7 @@ li code {
   .s1     { color: $solar-cyan !important; }                                             /* Literal.String.Single */
   //.ss     { color: #990073 }                                          /* Literal.String.Symbol */
   //.il     { color: #009999 }                                          /* Literal.Number.Integer.Long */
-  div { .gd, .gd .x, .gi, .gi .x { display: block; }}
+  div { .gd, .gd .x, .gi, .gi .x { display: inline-block; width: 100%; }}
 }
 
 .highlight, .gist-highlight {


### PR DESCRIPTION
Original issue: https://github.com/imathis/octopress/issues/126
