### PR TITLE
Improved support for non Latin characters in category names

### DIFF
--- a/plugins/category_generator.rb
+++ b/plugins/category_generator.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+#
 # Jekyll category page generator.
 # http://recursive-design.com/projects/jekyll-plugins/
 #
@@ -16,7 +18,6 @@
 # - category_dir:          The subfolder to build category pages in (default is 'categories').
 # - category_title_prefix: The string used before the category name in the page title (default is
 #                          'Category: ').
-require "unicode_utils"
 
 module Jekyll
 
@@ -69,7 +70,7 @@ module Jekyll
       if self.layouts.key? 'category_index'
         dir = self.config['category_dir'] || 'categories'
         self.categories.keys.each do |category|
-          self.write_category_index(File.join(dir, UnicodeUtils.nfkd(category).gsub(/[^\x00-\x7F]/, '').gsub(/_|\W/, '-').gsub(/-{2,}/, '-').to_s), category)
+          self.write_category_index(File.join(dir, category.gsub(/_|\P{Word}/, '-').gsub(/-{2,}/, '-')), category)
         end
 
       # Throw an exception if the layout couldn't be found.
@@ -106,7 +107,7 @@ module Jekyll
     def category_links(categories)
       dir = @context.registers[:site].config['category_dir']
       categories = categories.sort!.map do |item|
-        "<a class='category' href='/#{dir}/#{UnicodeUtils.nfkd(item).gsub(/[^\x00-\x7F]/, '').gsub(/_|\W/, '-').gsub(/-{2,}/, '-').to_s}/'>#{item}</a>"
+        "<a class='category' href='/#{dir}/#{item.gsub(/_|\P{Word}/, '-').gsub(/-{2,}/, '-')}/'>#{item}</a>"
       end
 
       case categories.length


### PR DESCRIPTION
I have tested this under ruby 1.9.2p0 and 1.9.1p378.

It works like this:
- "Wordpress" -> "Wordpress" (intact)
- "Hello World" -> "Hello-World"
- "ó, â, ç, Í, Ü, ä" -> "ó-â-ç-Í-Ü-ä"
- "日本語。カテゴリー名" -> "日本語-カテゴリー名" (Japanese)
- "中文_分類" -> "中文-分類" (Chinese)

Please give it a try and consider merging it.

Thanks for this great framework. :-)
