### PR TITLE
Fixes #150. Strip leading path before checking for excluded file.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -209,7 +209,7 @@ desc "copy dot files for deployment"
 task :copydot do
   exclusions = [".", "..", ".DS_Store"]
   Dir["#{source_dir}/**/.*"].each do |file|
-    if !File.directory?(file) && !exclusions.include?(file)
+    if !File.directory?(file) && !exclusions.include?(File.basename(file))
       cp(file, file.gsub(/#{source_dir}/, "#{public_dir}"));
     end
   end


### PR DESCRIPTION
A quick trip to irb is enlightening: 

```
Dir["#{source_dir}/**/.*"]
```

will populate the array with full pathnames, and these will never match the exclusions.  Still fairly new to ruby, so not sure if this is the most efficient fix.
