### PR TITLE
Removing glob because globbing does not pick up dotfiles.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -225,7 +225,7 @@ desc "deploy public directory to github pages"
 multitask :push do
   puts "## Deploying branch to Github Pages "
   (Dir["#{deploy_dir}/*"]).each { |f| rm_rf(f) }
-  system "cp -R #{public_dir}/* #{deploy_dir}"
+  system "cp -R #{public_dir}/ #{deploy_dir}"
   puts "\n## copying #{public_dir} to #{deploy_dir}"
   cd "#{deploy_dir}" do
     system "git add ."


### PR DESCRIPTION
Removing glob because globbing does not pick up dotfiles. According to the `cp()` manpages on OSX 10.6: -R will only copy the contents of a directory if specified as `cp -R dir/`. I do not know if this is true for Linux.
