### PR TITLE
Makes analytics a little more generic

### DIFF
--- a/.themes/classic/source/_includes/analytics.html
+++ b/.themes/classic/source/_includes/analytics.html
@@ -1,0 +1,2 @@
+{% include google_analytics.html %}
+{% include custom/analytics.html %}

--- a/.themes/classic/source/_includes/custom/analytics.html
+++ b/.themes/classic/source/_includes/custom/analytics.html
@@ -1,0 +1,1 @@
+<!-- custom analytics code, such as for getclicky.com -->

--- a/.themes/classic/source/_layouts/default.html
+++ b/.themes/classic/source/_layouts/default.html
@@ -10,7 +10,7 @@
   </div>
   <footer role="contentinfo">{% include footer.html %}</footer>
   {% include disqus.html %}
-  {% include google_analytics.html %}
+  {% include analytics.html %}
   {% include google_plus_one.html %}
   {% include twitter_sharing.html %}
 </body>


### PR DESCRIPTION
Created a generic analytics.html include which includes the google_analytics.html by default and also the custom/analytics.html include which can contain custom analytics code such as for getclicky.com and others.  Updated the default layout to include the generic analytics.html include instead of directly including the google_analytics.html one only.

If this isn't something you think is necessary in the Octopress core, I understand.  But let me know what you think.

Thanks!
Joey
