### PR TITLE
"stackoverflow flair" aside.

### DIFF
--- a/.themes/classic/source/_includes/asides/stackoverflow.html
+++ b/.themes/classic/source/_includes/asides/stackoverflow.html
@@ -1,0 +1,8 @@
+{% if site.stackoverflow_user_name %}
+<section>
+  <h1>Stack Overflow</h1>
+  <a href="http://stackoverflow.com/users/{{site.stackoverflow_user_id}}/{{site.stackoverflow_user_name}}">
+  <img src="http://stackoverflow.com/users/flair/{{site.stackoverflow_user_id}}.png" width="208" height="58" alt="profile for {{ site.stackoverflow_user_name }} at Stack Overflow, Q&amp;A for professional and enthusiast programmers" title="profile for {{ site.stackoverflow_user_name }} at Stack Overflow, Q&amp;A for professional and enthusiast programmers">
+  </a>
+</section>
+{% endif %}

--- a/_config.yml
+++ b/_config.yml
@@ -36,7 +36,7 @@ excerpt_link: "Read on &rarr;"  # "Continue reading" link text at the bottom of 
 
 # list each of the sidebar modules you want to include, in the order you want them to appear.
 # To add custom asides, create files in /source/_includes/custom/asides/ and add them to the list like 'custom/asides/custom_aside_name.html'
-default_asides: [asides/recent_posts.html, asides/github.html, asides/twitter.html, asides/delicious.html, asides/pinboard.html]
+default_asides: [asides/recent_posts.html, asides/github.html, asides/twitter.html, asides/delicious.html, asides/pinboard.html, asides/stackoverflow.html]
 
 # Each layout uses the default asides, but they can have their own asides instead. Simply uncomment the lines below
 # and add an array with the asides you want to use.
@@ -80,3 +80,7 @@ disqus_show_comment_count: false
 
 # Google Analytics
 google_analytics_tracking_id:
+
+# Stack Overlfow
+stackoverflow_user_name:
+stackoverflow_user_id:


### PR DESCRIPTION
This aside simply displays the official "stackoverflow flair" image. The _config.yml settings are the user name (e.g. "viggio24" in my case) and the user numerical id (e.g. "232155" in my case). The aside is displayed if the user name is specified, but obviously the two IDs must match. S.O. provides the possibility to change the colors of this aside, this can be added as extra configuration in the future.
