### PR TITLE
Add Piwik tracking as an alternative to Google Analytics

### DIFF
--- a/.themes/classic/source/_includes/piwik.html
+++ b/.themes/classic/source/_includes/piwik.html
@@ -1,0 +1,10 @@
+{% if site.piwik_url and site.piwik_site_id %}
+  <script type="text/javascript">
+    (function(){
+      var pkBaseURL = (("https:" == document.location.protocol) ? "https://{{ site.piwik_url }}/" : "http://{{ site.piwik_url }}/");
+      document.write(unescape("%3Cscript src='" + pkBaseURL + "piwik.js' type='text/javascript'%3E%3C/script%3E"));
+      try { var piwikTracker = Piwik.getTracker(pkBaseURL + "piwik.php", {{ site.piwik_site_id }}); piwikTracker.trackPageView(); piwikTracker.enableLinkTracking(); } catch( err ) {}
+    })();
+  </script>
+  <noscript><p><img src="http://{{ site.piwik_url }}/piwik.php?idsite={{ site.piwik_site_id }}" style="border:0" alt="" /></p></noscript>
+{% endif %}

--- a/.themes/classic/source/_layouts/default.html
+++ b/.themes/classic/source/_layouts/default.html
@@ -13,5 +13,6 @@
   {% include google_analytics.html %}
   {% include google_plus_one.html %}
   {% include twitter_sharing.html %}
+  {% include piwik.html %}  
 </body>
 </html>

--- a/_config.yml
+++ b/_config.yml
@@ -80,3 +80,7 @@ disqus_show_comment_count: false
 
 # Google Analytics
 google_analytics_tracking_id:
+
+# Piwik Analytics
+piwik_url:        # Your Piwik installation URL. Leave out the protocol and trailing slash. E.g. yourdomain.com/piwik
+piwik_site_id:    # ID number (in Piwik) of the site you you want to track.


### PR DESCRIPTION
I use [Piwik](http://piwik.org/) in addition to Google Analytics to track my sites, so I thought I'd add support for it in Octopress. Piwik seems to be a popular open source alternative to GA, and considering the Octopress community largely consists of open source enthusiasts I'm guessing other people might have a use for this too.
