### PR TITLE
Fixed using a video tag for audio showing the incorrect drop shadow.

### DIFF
--- a/.themes/classic/sass/partials/_blog.scss
+++ b/.themes/classic/sass/partials/_blog.scss
@@ -47,6 +47,7 @@ article {
     @extend .flex-content;
     @extend .basic-alignment;
     @include shadow-box;
+    min-height: 50px;
   }
   video, .flash-video { margin: 0 auto 1.5em; }
   video { display: block; width: 100%; }


### PR DESCRIPTION
Fixed using a video tag for audio showing the incorrect drop shadow.

This is how it looked:

![Before](http://mswadling.com/images/code/octopress_before.png)

This is how it looks now:

![After](http://mswadling.com/images/code/octopress_after.png)
