### PR TITLE
Converting partial content in render_partial

### DIFF
--- a/plugins/render_partial.rb
+++ b/plugins/render_partial.rb
@@ -31,11 +31,9 @@ module Jekyll
     def initialize(tag_name, markup, tokens)
       @file = nil
       @raw = false
-      @convert = false
       if markup =~ /^(\S+)\s?(\w+)?/
         @file = $1.strip
         @raw = $2 == 'raw'
-        @convert = $2 == 'convert'
       end
       super
     end
@@ -61,15 +59,16 @@ module Jekyll
           partial = Liquid::Template.parse(contents)
           context.stack do
             contents = partial.render(context)
-            if @convert
-              site = context.registers[:site]
-              ext = File.extname(@file)
-
-              converter = site.converters.find { |c| c.matches(ext) }
-              contents = converter.convert(contents) unless converter.nil?
-            end
             
-            contents
+            site = context.registers[:site]
+            ext = File.extname(@file)
+            converter = site.converters.find { |c| c.matches(ext) }
+            
+            if converter.nil?
+              contents
+            else
+              converter.convert(contents)
+            end
           end
         end
       end


### PR DESCRIPTION
### Problem:

I want to be able to include Markdown partials in HTML pages. Current implementation requires me to use _capture_+_markdownify_ filter.
### Solution:

_render_partial_ has a special argument _covert_ (just like _raw_ argument) that enables content converting.

Twitter discussion: https://twitter.com/octopress/status/120222860286496768
