### PR TITLE
Proper atom feed xml escaping

### DIFF
--- a/.themes/classic/source/atom.xml
+++ b/.themes/classic/source/atom.xml
@@ -4,21 +4,21 @@ layout: nil
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
 
-  <title>{{ site.title }}</title>
+  <title>{{ site.title | xml_escape }}</title>
   <link href="{{ site.url }}/atom.xml" rel="self"/>
   <link href="{{ site.url }}/"/>
   <updated>{{ site.time | date_to_xmlschema }}</updated>
   <id>{{ site.url }}/</id>
   <author>
-    <name>{{ site.author }}</name>
+    <name>{{ site.author | xml_escape }}</name>
     {% if site.email %}
-      <email>{{ site.email }}</email>
+      <email>{{ site.email | xml_escape }}</email>
     {% endif %}
   </author>
 
   {% for post in site.posts limit: 20 %}
   <entry>
-    <title>{{ post.title }}</title>
+    <title>{{ post.title | xml_escape }}</title>
     <link href="{{ site.url }}{{ post.url }}"/>
     <updated>{{ post.date | date_to_xmlschema }}</updated>
     <id>{{ site.url }}{{ post.id }}</id>


### PR DESCRIPTION
Hey there!

Just discovered that content that goes into the atom XML feed isn't properly escaped. In particular, I can break the validity by adding "&" to either blog or an article title, author name or use "<Name> my@email.com" or something of sorts as the user name. In any case, escaping never hurts, right?

Cheers,
- A
