### PR TITLE
Add generator tag to Atom feed.

### DIFF
--- a/.themes/classic/source/atom.xml
+++ b/.themes/classic/source/atom.xml
@@ -15,6 +15,7 @@ layout: nil
       <email>{{ site.email | xml_escape }}</email>
     {% endif %}
   </author>
+  <generator uri="http://octopress.org/">Octopress</generator>
 
   {% for post in site.posts limit: 20 %}
   <entry>


### PR DESCRIPTION
generator is an optional element, but let's give credit where it's due.
Besides, it can be helpful to feed consumers to know what tool generated the file.
