### PR TITLE
changing two system() calls to use corresponding FileUtils methods

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -230,7 +230,7 @@ multitask :push do
   (Dir["#{deploy_dir}/*"]).each { |f| rm_rf(f) }
   Rake::Task[:copydot].invoke(public_dir, deploy_dir)
   puts "\n## copying #{public_dir} to #{deploy_dir}"
-  system "cp -R #{public_dir}/* #{deploy_dir}"
+  copy_entry "#{public_dir}", "#{deploy_dir}"
   cd "#{deploy_dir}" do
     system "git add ."
     system "git add -u"


### PR DESCRIPTION
eed92b63    is related to issue #190
bc14e149    simply removed a system() call that seemed to duplicate a FileUtils call just a few lines above it.

I'm not able to test these on OSX.
