### PR TITLE
New generate_only Rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -54,6 +54,16 @@ task :generate do
   system "jekyll"
 end
 
+# usage rake generate_only[my-post]
+desc "Generate only the specified post (much faster)"
+task :generate_only, :filename do |t, args|
+  puts "## Stashing other posts"
+  Rake::Task["isolate"].invoke(args.filename)
+  Rake::Task["generate"].execute
+  puts "## Restoring stashed posts"
+  system "rake integrate"
+end
+
 desc "Watch the site and regenerate when it changes"
 task :watch do
   raise "### You haven't set anything up yet. First run `rake install` to set up an Octopress theme." unless File.directory?(source_dir)


### PR DESCRIPTION
Just a little Rake task to wrap up `rake isolate`, `rake generate` and `rake integrate` in one convenient task. In case you wonder why I use `system` to call the last one, neither `#invoke` nor `#execute` have worked for me and I didn't really feel like spending time on investigating why. 
