### PR TITLE
Fix a typo in sass template

### DIFF
--- a/.themes/classic/sass/partials/_blog.scss
+++ b/.themes/classic/sass/partials/_blog.scss
@@ -73,7 +73,7 @@ article {
     @extend .sans;
     p.meta {
       margin-bottom: .8em;
-      font-size: .85em
+      font-size: .85em;
       clear: both;
       overflow: hidden;
     }


### PR DESCRIPTION
there's a missing ';' which causes the generate task to fail. this is just a small fix.
