### PR TITLE
proxy support for gist_tag

### DIFF
--- a/plugins/gist_tag.rb
+++ b/plugins/gist_tag.rb
@@ -71,7 +71,13 @@ module Jekyll
     def get_gist_from_web(gist, file)
       gist_url          = get_gist_url_for gist, file
       raw_uri           = URI.parse gist_url
-      https             = Net::HTTP.new raw_uri.host, raw_uri.port
+      proxy             = ENV['http_proxy']
+      if proxy
+        proxy_uri       = URI.parse(proxy)
+        https           = Net::HTTP::Proxy(proxy_uri.host, proxy_uri.port).new raw_uri.host, raw_uri.port
+      else
+        https           = Net::HTTP.new raw_uri.host, raw_uri.port
+      end
       https.use_ssl     = true
       https.verify_mode = OpenSSL::SSL::VERIFY_NONE
       request           = Net::HTTP::Get.new raw_uri.request_uri


### PR DESCRIPTION
It's better to treat HTTP_PROXY environment variable for all.
