### PR TITLE
Only include facebook js if it is to be used

### DIFF
--- a/.themes/classic/source/_includes/facebook_like.html
+++ b/.themes/classic/source/_includes/facebook_like.html
@@ -1,3 +1,4 @@
+{% if site.facebook_like %}
 <div id="fb-root"></div>
 <script>(function(d, s, id) {
   var js, fjs = d.getElementsByTagName(s)[0];
@@ -6,3 +7,4 @@
   js.src = "//connect.facebook.net/en_US/all.js#appId=212934732101925&xfbml=1";
   fjs.parentNode.insertBefore(js, fjs);
 }(document, 'script', 'facebook-jssdk'));</script>
+{% endif %}


### PR DESCRIPTION
The current theme includes the facebook javascript even if `facebook_like` is disabled, causing an unnecessary extra js load by the browser. This simply wraps it in an `if` statement like the Google+ code.
