### PR TITLE
Provide a way to configure font family for subtitle.

### DIFF
--- a/.themes/classic/sass/base/_typography.scss
+++ b/.themes/classic/sass/base/_typography.scss
@@ -4,6 +4,7 @@ $serif: "PT Serif", Georgia, Times, "Times New Roman", serif !default;
 $mono: Menlo, Monaco, "Andale Mono", "lucida console", "Courier New", monospace !default;
 $heading-font-family: "PT Serif", "Georgia", "Helvetica Neue", Arial, sans-serif !default;
 $header-title-font-family: $heading-font-family !default;
+$header-subtitle-font-family: $heading-font-family !default;
 
 // Fonts
 .heading {
@@ -20,6 +21,9 @@ body > header h1 {
   font-weight: normal;
   line-height: 1.2em;
   margin-bottom: 0.6667em;
+}
+body > header h2 {
+  font-family: $header-subtitle-font-family;
 }
 
 body {

--- a/.themes/classic/sass/custom/_fonts.scss
+++ b/.themes/classic/sass/custom/_fonts.scss
@@ -7,3 +7,4 @@
 //$mono: "Courier", monospace;
 //$heading-font-family: "Verdana", sans-serif;
 //$header-title-font-family: "Futura", sans-serif;
+//$header-subtitle-font-family: "Futura", sans-serif;


### PR DESCRIPTION
It might be that I'm new to SASS and/or the class (or any) theme for Octopress, but I was unable to easily tweak the font for my site's subtitle. Even changing the `$heading-font-family` setting seemed to work for the rest of the `H1`, `H2`, `H3`, etc. elements, but it had no impact at all on the subtitle. 

I thought about tying it to `$header-title-font-family` but I figure this way it is a little more flexible in the case that someone wants to use a different font for each.
