### PR TITLE
Option for deploying static sites to Amazon S3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,12 @@ ssh_port       = "22"
 document_root  = "~/website.com/"
 deploy_default = "rsync"
 
+# Use this if deploying to an S3 bucket
+# (must have s3cmd installed and deploy_default set to "s3")
+# See also: http://aws.typepad.com/aws/2011/02/host-your-static-website-on-amazon-s3.html
+s3_bucket = "bucket-name"
+s3_prefix = "" # In the form of "/path/" (note the leading and trailing slashes)
+
 # This will be configured for you when you run config_deploy
 deploy_branch  = "gh-pages"
 
@@ -222,6 +228,12 @@ desc "Deploy website via rsync"
 task :rsync do
   puts "## Deploying website via Rsync"
   ok_failed system("rsync -avze 'ssh -p #{ssh_port}' --delete #{public_dir}/ #{ssh_user}:#{document_root}")
+end
+
+desc "Deploy website via s3cmd"
+task :s3 do
+  puts "## Deploying website via s3cmd"
+  ok_failed system("s3cmd --acl-public sync #{public_dir}/ s3://#{s3_bucket}#{s3_prefix}")
 end
 
 desc "deploy public directory to github pages"


### PR DESCRIPTION
I found Octopress to be the perfect tool for generating static blog pages for hosting in Amazon's S3. I've modified the Rakefile to support deployment in this way. It has one requirement, s3cmd, which may be installed with apt-get on any Linux system.

For more information on setting up an S3 bucket to support hosting a static website, see http://aws.typepad.com/aws/2011/02/host-your-static-website-on-amazon-s3.html.
