### PR TITLE
Add disqus identifier

### DIFF
--- a/source/_includes/article.html
+++ b/source/_includes/article.html
@@ -9,7 +9,8 @@
       <p class="meta">
         {% include post/date.html %}{{ time }}
         {% if site.disqus_short_name and page.comments != false and site.disqus_show_comment_count == true %}
-         | <a href="{% if index %}{{ root_url }}{{ post.url }}{% endif %}#disqus_thread">Comments</a>
+        | <a href="{% if index %}{{ root_url }}{{ post.url }}{% endif %}#disqus_thread"
+          data-disqus-identifier="{% if post.meta.disqus_id %}{{ post.meta.disqus_id }}{% else %}{{ site.url }}{{ post.url }}{% endif %}">Comments</a>
         {% endif %}
       </p>
     {% endunless %}


### PR DESCRIPTION
Currently, if the `site_url` is different from `root.url`, comments on thread pages will still work, but comment counts on the homepage will not work.

This change fixes this issue by adding the canonical URL in the `data-disqus-identifier` attribute.  If the post has a `meta.disqus_id` field this will be used to override this identifier instead.  [According to the documentation](http://docs.disqus.com/developers/universal/#comment-count) using the disqus identifier is the preferred method of identifying posts.
