### PR TITLE
:copydot needs to do something smarter if destination directory does not exist

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -224,7 +224,10 @@ task :copydot do
   exclusions = [".", "..", ".DS_Store"]
   Dir["#{source_dir}/**/.*"].each do |file|
     if !File.directory?(file) && !exclusions.include?(File.basename(file))
-      cp(file, file.gsub(/#{source_dir}/, "#{public_dir}"));
+      copied_file = file.gsub(/#{source_dir}/, "#{public_dir}")
+      if File.directory?(copied_file)
+        cp(file, copied_file)
+      end
     end
   end
 end


### PR DESCRIPTION
Trying to deploy on this branch was giving me issues because `:copydot` was not as smart as it could be/should be. I'm not actually sure what the expected behavior should be in this case, but figured I'd start with this PR and make changes as needed.

Here are examples of three files that `:copydot` was trying to copy:

```
source/._.DS_Store
source/images/._dark_leather.png
source/_posts/._2011-11-09-reboot.markdown
```

The first two are just annoying. I'm not sure why my system is generating `._.DS_Store` instead of simply `.DS_store` but it is. If this is somewhat standard, maybe it should be added to the exclude? As for `._dark_leather.png`, I think that is a Finder thing. Not sure how to get past those. Maybe exclude needs to be configurable? Of course I'm not sure how anyone would know whether or not these files are being copied unless they are paying super close attention...

Which brings me to the third file. The only reason I found any of this out was because this particular gem caused the deploy to fail because I don't have a `_posts` folder in `public/` at all. The `cp` command was failing.

Anyway, this first pass was a quick fix to simply not copy a dot file from `source/` to `public/` if the destination directory does not exist. I'm not sure this is the expected behavior, though. Alternate behavior would be to create the destination directory if it does not exist (`mkdir -p`). I like what it does now as it is probably closer to what is expected.

On a somewhat related note, I thought Jekyll was already doing a lot of copying and had the capability of excluding files. Does it exclude dot files by default? Is that why this task exists? If not, what types of dot files is Octopress trying to account for that aren't already taken into account by Jekyll?
