### PR TITLE
Fix/line wrap after code

### DIFF
--- a/sass/partials/_syntax.scss
+++ b/sass/partials/_syntax.scss
@@ -89,8 +89,7 @@ h3.filename {
 p, li {
   code {
     @extend .mono;
-    display: inline-block;
-    white-space: no-wrap;
+    white-space: pre;
     background: #fff;
     font-size: .8em;
     line-height: 1.5em;


### PR DESCRIPTION
Using `display: inline-block` allows punctuation characters following code blocks to wrap to the next line.  You can see [in this example](http://jsfiddle.net/treyh/xNY8w/) when a `<code>` element is followed by a punctuation character at the end of a line, the punctuation character may wrap down to the next line resulting in lines that start with `.` and `,`.  This unexpected behavior is resolved when the `display: inline-block` declaration is removed.

Removing `display: inline-block` allows `<code>` elements to split on `-` characters.  To avoid this, `white-space: pre` can be used.  The `pre` white-space value [is well supported](http://www.quirksmode.org/css/whitespace.html) and is better suited for displaying code than `white-space: nowrap`.  The `nowrap` value allows breaks on punctuation (such as `-`).  The `pre` value also breaks on linebreaks while `nowrap` does not.
