### PR TITLE
Introduce distinction between preview/productive site generation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -200,6 +200,13 @@ end
 
 desc "Default deploy task"
 task :deploy do
+  # Check if preview posts exist, which should not be published
+  if File.exists?(".preview-mode")
+    puts "## Found posts in preview mode, regenerating files ..."
+    File.delete(".preview-mode")
+    Rake::Task[:generate].execute
+  end
+
   Rake::Task[:copydot].invoke(source_dir, public_dir)
   Rake::Task["#{deploy_default}"].execute
 end

--- a/plugins/preview_unpublished.rb
+++ b/plugins/preview_unpublished.rb
@@ -24,8 +24,11 @@ module Jekyll
 
           # Monkeypatch:
           # On preview environment (localhost), publish all posts
-          if ENV.has_key?('OCTOPRESS_ENV') && ENV['OCTOPRESS_ENV'] == 'preview'
+          if ENV.has_key?('OCTOPRESS_ENV') && ENV['OCTOPRESS_ENV'] == 'preview' && post.data.has_key?('published') && post.data['published'] == false
             post.published = true
+            # Set preview mode flag (if necessary), `rake generate` will check for it
+            # to prevent pushing preview posts to productive environment
+            File.open(".preview-mode", "w") {}
           end
 
           if post.published && (self.future || post.date <= self.time)


### PR DESCRIPTION
Posts which contain the YAML attribute `published: false` are usually
not generated by Jekyll. With this patch they can be previewed just
like published posts on localhost using `rake watch`or `rake preview`.

NOTICE: Before pushing to the productive environment, use `rake generate`
to update the public directory and remove posts which are flagged not to be
published.
