### PR TITLE
Minor improvement to Titlecase plugin

### DIFF
--- a/plugins/titlecase.rb
+++ b/plugins/titlecase.rb
@@ -11,8 +11,8 @@ class String
     # capitalize first and last words
     x.first.to_s.smart_capitalize!
     x.last.to_s.smart_capitalize!
-    # small words after colons or periods are capitalized
-    x.join(" ").gsub(/(:|\.)\s?(\W*#{small_words.join("|")}\W*)\s/) { "#{$1} #{$2.smart_capitalize} " }
+    # small words are capitalized after colon, period, exclamation mark, question mark
+    x.join(" ").gsub(/(:|\.|!|\?)\s?(\W*#{small_words.join("|")}\W*)\s/) { "#{$1} #{$2.smart_capitalize} " }
   end
 
   def titlecase!


### PR DESCRIPTION
I added "!" and "?" to the list of symbols after which a "little word" should nevertheless be capitalised. I know that it's not a hard-and-fast rule, but it seems appropriate much more often than not. I had a specific title that suffered from wrong capitalisation.
