### PR TITLE
Nested lists should not have margin-bottom

### DIFF
--- a/.themes/classic/sass/base/_typography.scss
+++ b/.themes/classic/sass/base/_typography.scss
@@ -61,12 +61,12 @@ h6, section h5, section section h4, section section section h3 {
 p, blockquote, ul, ol { margin-bottom: 1.5em; }
 
 ul { list-style-type: disc;
-  ul { list-style-type: circle;
-    ul { list-style-type: square; }}}
+  ul { list-style-type: circle; margin-bottom: 0px;
+    ul { list-style-type: square; margin-bottom: 0px; }}}
 
 ol { list-style-type: decimal;
-  ol { list-style-type: lower-alpha;
-    ol { list-style-type: lower-roman; }}}
+  ol { list-style-type: lower-alpha; margin-bottom: 0px;
+    ol { list-style-type: lower-roman; margin-bottom: 0px; }}}
 
 ul, ol { &, ul, ol { margin-left: 1.3em; }}
 


### PR DESCRIPTION
If you have a nested list like this:

```
* foo
  * bar
* baz
```

then the output looks like _baz_ is actually on a separate list. I suggest removing the margin-bottom for nested lists.
