### PR TITLE
Ignore Vim .swp files during deploy

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -212,6 +212,7 @@ desc "copy dot files for deployment"
 task :copydot, :source, :dest do |t, args|
   exclusions = [".", "..", ".DS_Store"]
   Dir["#{args.source}/**/.*"].each do |file|
+    next if File.basename(file) =~ /^\..*\.swp$/ # Ignore Vim swap files
     if !File.directory?(file) && !exclusions.include?(File.basename(file))
       cp(file, file.gsub(/#{args.source}/, "#{args.dest}"));
     end


### PR DESCRIPTION
"rake deploy" fails if Vim is editing a post or page file because the Vim swap file (.$filename.swp) creates an error. Excluding that file glob so deploy works again.
