### PR TITLE
Set umask to world readable before generating site

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -50,6 +50,7 @@ desc "Generate jekyll site"
 task :generate do
   raise "### You haven't set anything up yet. First run `rake install` to set up an Octopress theme." unless File.directory?(source_dir)
   puts "## Generating Site with Jekyll"
+  File.umask(022)
   system "compass compile --css-dir #{source_dir}/stylesheets"
   system "jekyll"
 end
@@ -59,8 +60,8 @@ task :watch do
   raise "### You haven't set anything up yet. First run `rake install` to set up an Octopress theme." unless File.directory?(source_dir)
   puts "Starting to watch source with Jekyll and Compass."
   system "compass compile --css-dir #{source_dir}/stylesheets" unless File.exist?("#{source_dir}/stylesheets/screen.css")
-  jekyllPid = Process.spawn("jekyll --auto")
-  compassPid = Process.spawn("compass watch")
+  jekyllPid = Process.spawn("jekyll --auto", :umask=>022)
+  compassPid = Process.spawn("compass watch", :umask=>022)
 
   trap("INT") {
     [jekyllPid, compassPid].each { |pid| Process.kill(9, pid) rescue Errno::ESRCH }
@@ -75,8 +76,8 @@ task :preview do
   raise "### You haven't set anything up yet. First run `rake install` to set up an Octopress theme." unless File.directory?(source_dir)
   puts "Starting to watch source with Jekyll and Compass. Starting Rack on port #{server_port}"
   system "compass compile --css-dir #{source_dir}/stylesheets" unless File.exist?("#{source_dir}/stylesheets/screen.css")
-  jekyllPid = Process.spawn("jekyll --auto")
-  compassPid = Process.spawn("compass watch")
+  jekyllPid = Process.spawn("jekyll --auto", :umask=>022)
+  compassPid = Process.spawn("compass watch", :umask=>022)
   rackupPid = Process.spawn("rackup --port #{server_port}")
 
   trap("INT") {


### PR DESCRIPTION
Ensure that calls to Jekyll and Compass force the umask for
those processes to be 022.  This ensures that any files in public/
will be world-readable, which is particularly important for anyone
with stricter umasks (e.g., the paranoid 077) using rsync for deploy.

This fixes #307.

Signed-off-by: Emil Sit sit@emilsit.net
