### PR TITLE
Added !default to noise-bg

### DIFF
--- a/.themes/classic/sass/base/_theme.scss
+++ b/.themes/classic/sass/base/_theme.scss
@@ -1,4 +1,4 @@
-$noise-bg: image-url('noise.png') top left;
+$noise-bg: image-url('noise.png') top left !default;
 $img-border: inline-image('dotted-border.png');
 
 // Main Link Colors


### PR DESCRIPTION
This lets us override the noise.png background image in the custom SCSS
files if we choose.
