### PR TITLE
Removed redeclaration of sidebar-border.

### DIFF
--- a/.themes/classic/sass/base/_theme.scss
+++ b/.themes/classic/sass/base/_theme.scss
@@ -41,7 +41,7 @@ $sidebar-link-color-hover: $link-color-hover !default;
 $sidebar-link-color-active: $link-color-active !default;
 $sidebar-color: change-color(mix($text-color, $sidebar-bg, 80), $hue: hue($sidebar-bg), $saturation: saturation($sidebar-bg)/2) !default;
 $sidebar-border: desaturate(darken($sidebar-bg, 7), 10) !default;
-$sidebar-border: darken($sidebar-bg, 7) !default;
+$sidebar-border-hover: darken($sidebar-bg, 7) !default;
 $sidebar-link-color-subdued: lighten($sidebar-color, 20) !default;
 $sidebar-link-color-subdued-hover: $sidebar-link-color-hover !default;
 $twitter-status-link: lighten($sidebar-link-color-subdued, 15) !default;


### PR DESCRIPTION
A mistake? Looks like it was redefined right there. Not exactly sure why. Figured it would be the hover variable (though that is not used anywhere). 
