### PR TITLE
Added anchor tag to jump past content above the <!-- more --> tag.

### DIFF
--- a/.themes/classic/source/_includes/article.html
+++ b/.themes/classic/source/_includes/article.html
@@ -20,7 +20,7 @@
   {% capture excerpted %}{{ content | has_excerpt }}{% endcapture %}
   {% if excerpted == 'true' %}
     <footer>
-      <a rel="full-article" href="{{ root_url }}{{ post.url }}">{{ site.excerpt_link }}</a>
+      <a rel="full-article" href="{{ root_url }}{{ post.url }}#octojump">{{ site.excerpt_link }}</a>
     </footer>
   {% endif %}
 {% else %}

--- a/plugins/octopress_filters.rb
+++ b/plugins/octopress_filters.rb
@@ -15,6 +15,8 @@ module OctopressFilters
     end
   end
   def post_filter(input)
+    # replace the <!-- more --> tag with an anchor
+    input.gsub!(/<!--\s*more\s*-->/,'<!-- more --><a id="octojump"></a>')
     input = unwrap(input)
     RubyPants.new(input).to_html
   end


### PR DESCRIPTION
I modifed themes/classic/source/_includes/article.html and plugins/octopress_filters.rb to add an `<a id='octojump'></a>` tag after the `<!-- more -->` tag and to append #octopress to the 'Read on ->' link.  This should probably use the _config.yml file to set the actual anchor id (or disable it), but I could not figure out how to access the config from octopress_filters.rb.

The purpose of this is to avoid having to scroll past content that has already been read prior to clicking on the 'Read on ->' link and is consistent with the way other sites using article jumps operate.
