### PR TITLE
Find a bug when 'category_dir' is empty in _config.yml

### DIFF
--- a/plugins/category_generator.rb
+++ b/plugins/category_generator.rb
@@ -104,9 +104,13 @@ module Jekyll
     # Loops through the list of category pages and processes each one.
     def write_category_indexes
       if self.layouts.key? 'category_index'
-        dir = self.config['category_dir'] || 'categories'
+        dir = self.config['category_dir']
         self.categories.keys.each do |category|
-          self.write_category_index(File.join(dir, category.gsub(/_|\P{Word}/, '-').gsub(/-{2,}/, '-').downcase), category)
+          if dir.nil? or dir.empty?
+            self.write_category_index(category.gsub(/_|\P{Word}/, '-').gsub(/-{2,}/, '-').downcase, category)
+          else
+            self.write_category_index(File.join(dir, category.gsub(/_|\P{Word}/, '-').gsub(/-{2,}/, '-').downcase), category)
+          end
         end
 
       # Throw an exception if the layout couldn't be found.
@@ -143,7 +147,11 @@ module Jekyll
     def category_links(categories)
       dir = @context.registers[:site].config['category_dir']
       categories = categories.sort!.map do |item|
-        "<a class='category' href='/#{dir}/#{item.gsub(/_|\P{Word}/, '-').gsub(/-{2,}/, '-').downcase}/'>#{item}</a>"
+        if dir.nil? or dir.empty?
+          "<a class='category' href='/#{item.gsub(/_|\P{Word}/, '-').gsub(/-{2,}/, '-').downcase}/'>#{item}</a>"
+        else
+          "<a class='category' href='/#{dir}/#{item.gsub(/_|\P{Word}/, '-').gsub(/-{2,}/, '-').downcase}/'>#{item}</a>"
+        end
       end
 
       case categories.length


### PR DESCRIPTION
When category_dir is empty, the old behavior is generating per-category directory in default 'categories' path, but the category_links don't work.
I just generate category directories under root directory, and handle category_links properly.
