### PR TITLE
Fix delicious widget js error

### DIFF
--- a/.themes/classic/source/javascripts/octopress.js
+++ b/.themes/classic/source/javascripts/octopress.js
@@ -110,7 +110,7 @@ function wrapFlashVideos() {
 function renderDeliciousLinks(items) {
   var output = "<ul>";
   for (var i=0,l=items.length; i<l; i++) {
-    output += '<li><a href="' + items[i].u + '" title="Tags: ' + items[i].t.join(', ') + '">' + items[i].d + '</a></li>';
+    output += '<li><a href="' + items[i].u + '" title="Tags: ' + (items[i].t == "" ? "" : items[i].t.join(', ')) + '">' + items[i].d + '</a></li>';
   }
   output += "</ul>";
   $('#delicious').html(output);


### PR DESCRIPTION
JS error occured when there's no tags on bookmarks
Check if it's an empty string before join item[i].t
