### PR TITLE
Fix for vertical space below nested lists

### DIFF
--- a/.themes/classic/sass/base/_typography.scss
+++ b/.themes/classic/sass/base/_typography.scss
@@ -73,6 +73,7 @@ ol { list-style-type: decimal;
     ol { list-style-type: lower-roman; margin-bottom: 0px; }}}
 
 ul, ol { &, ul, ol { margin-left: 1.3em; }}
+ul, ol { ul, ol { margin-bottom: 0em; }}
 
 strong { font-weight: bold; }
 


### PR DESCRIPTION
In nested lists, eg:

```
- The quick brown fox jumped over the lazy dog
  - But was a fat diabetic and failed
- The lazy dog was crushed and lived in traction the rest of its days
```

There's a 1.5em bottom margin on the inner unordered list. This patch adds some additional CSS which prevents the bottom margin on inner lists, both ordered and unordered.

Now, I ain't the best at these CSS things, so you might have to tweak it a (lot). It also might be that the bottom padding is intentional, but I think I found a working solution.

This is a "clean" patch, in that it doesn't also include an obnoxious merge commit in the middle. :)
