### PR TITLE
Setting "github_repo_count: 0" should cause 0 repositories to show.

### DIFF
--- a/.themes/classic/source/javascripts/github.js
+++ b/.themes/classic/source/javascripts/github.js
@@ -28,7 +28,7 @@ var github = (function(){
             return aDate > bDate ? -1 : 1;
           });
 
-          if (options.count) { repos.splice(options.count); }
+          if (options.count || options.count === 0) { repos.splice(options.count); }
           render(options.target, repos);
         }
       });


### PR DESCRIPTION
Because 0 is falsy in JS the splice isn't executed when the setting equals 0, and instead the default number of repositories is displayed. The fix checks for 0 exactly.

I suppose the whole loop could be avoided for a 0 count, but this seemed like the simplest change that would work without impacting anything else and staying in the spirit of splicing after the fetch & sort step.
