### PR TITLE
Disqus developer mode

### DIFF
--- a/.themes/classic/source/_includes/disqus.html
+++ b/.themes/classic/source/_includes/disqus.html
@@ -2,6 +2,7 @@
 {% if site.disqus_short_name and page.comments != false %}
 <script type="text/javascript">
       var disqus_shortname = '{{ site.disqus_short_name }}';
+			var disqus_developer = '{{ site.disqus_developer }}';
       {% if page.comments == true %}
         {% comment %} `page.comments` can be only be set to true on pages/posts, so we embed the comments here. {% endcomment %}
         // var disqus_developer = 1;

--- a/_config.yml
+++ b/_config.yml
@@ -91,6 +91,7 @@ delicious_count: 3
 # Disqus Comments
 disqus_short_name:
 disqus_show_comment_count: false
+disqus_developer: 0
 
 # Google Analytics
 google_analytics_tracking_id:


### PR DESCRIPTION
I've added a couple lines that allow you to enable disqus developer mode (doesn't verify URLs) in the _config.yml. Useful for local testing.
