### PR TITLE
Display mobile navigation when search is not configured.

### DIFF
--- a/.themes/classic/source/javascripts/octopress.js
+++ b/.themes/classic/source/javascripts/octopress.js
@@ -1,5 +1,5 @@
 function getNav() {
-  var mobileNav = $('nav[role=navigation] fieldset[role=search]').after('<fieldset class="mobile-nav"></fieldset>').next().append('<select></select>');
+  var mobileNav = $('nav[role=navigation] ul.subscription').after('<fieldset class="mobile-nav"></fieldset>').next().append('<select></select>');
   mobileNav.children('select').append('<option value="">Navigate&hellip;</option>');
   $('ul[role=main-navigation]').addClass('main-navigation');
   $('ul.main-navigation a').each(function(link) {


### PR DESCRIPTION
fixes #349

Before this, the mobile-nav was being added inside the search fieldset. Simply append the mobile-nav DOM after the subscription element.
