### PR TITLE
Fixed issue with `rake watch` rendering unpublished posts.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -76,7 +76,7 @@ task :preview do
   raise "### You haven't set anything up yet. First run `rake install` to set up an Octopress theme." unless File.directory?(source_dir)
   puts "Starting to watch source with Jekyll and Compass. Starting Rack on port #{server_port}"
   system "compass compile --css-dir #{source_dir}/stylesheets" unless File.exist?("#{source_dir}/stylesheets/screen.css")
-  jekyllPid = Process.spawn({"OCTOPRESS_ENV"=>"preview"}, "jekyll --auto")
+  jekyllPid = Process.spawn("jekyll --auto")
   compassPid = Process.spawn("compass watch")
   rackupPid = Process.spawn("rackup --port #{server_port}")
 


### PR DESCRIPTION
I've been using `rake watch` on my server to publish my site whenever I change anything, but unpublished posts were being published. It turns out that the `:watch` rake task was setting `OCTOPRESS_ENV=preview` so I've taken that out.
