### PR TITLE
Fixed issue with `rake watch` rendering unpublished posts.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,7 @@ task :watch do
   raise "### You haven't set anything up yet. First run `rake install` to set up an Octopress theme." unless File.directory?(source_dir)
   puts "Starting to watch source with Jekyll and Compass."
   system "compass compile --css-dir #{source_dir}/stylesheets" unless File.exist?("#{source_dir}/stylesheets/screen.css")
-  jekyllPid = Process.spawn({"OCTOPRESS_ENV"=>"preview"}, "jekyll --auto")
+  jekyllPid = Process.spawn("jekyll --auto")
   compassPid = Process.spawn("compass watch")
 
   trap("INT") {


### PR DESCRIPTION
I've fixed the issue with `rake watch` picking up unpublished posts. The `:watch` task was setting `OCTOPRESS_ENV=preview` so I've taken that out.
