### PR TITLE
Ability to blacklist specific github repos from aside

### DIFF
--- a/.themes/classic/source/_includes/asides/github.html
+++ b/.themes/classic/source/_includes/asides/github.html
@@ -17,10 +17,18 @@
             s.parentNode.insertBefore(jxhr, s);
         }
 
+        var blacklist = [];
+        {% if site.github_blacklist %}
+          {% for repo in site.github_blacklist %}
+            blacklist.push('{{repo}}');
+          {% endfor %}
+        {% endif %}
+
         github.showRepos({
             user: '{{site.github_user}}',
             count: {{site.github_repo_count}},
             skip_forks: {{site.github_skip_forks}},
+            blacklist: blacklist,
             target: '#gh_repos'
         });
     });

--- a/.themes/classic/source/javascripts/github.js
+++ b/.themes/classic/source/javascripts/github.js
@@ -7,6 +7,14 @@ var github = (function(){
     }
     t.innerHTML = fragment;
   }
+  function repoInBlacklist(repo, blacklist) {
+    if (blacklist) {
+      for (var i=0; i<blacklist.length; ++i) {
+        if (blacklist[i] == repo.name) { return true; }
+      }
+    }
+    return false;
+  }
   return {
     showRepos: function(options){
       $.ajax({
@@ -18,6 +26,7 @@ var github = (function(){
           if (!data || !data.repositories) { return; }
           for (var i = 0; i < data.repositories.length; i++) {
             if (options.skip_forks && data.repositories[i].fork) { continue; }
+            if (repoInBlacklist(data.repositories[i], options.blacklist)) { continue; }
             repos.push(data.repositories[i]);
           }
           repos.sort(function(a, b) {

--- a/_config.yml
+++ b/_config.yml
@@ -62,6 +62,11 @@ github_user:
 github_repo_count: 0
 github_show_profile_link: true
 github_skip_forks: true
+github_blacklist:
+# You can optionally blacklist repos from being displayed by putting their
+# names in the github_blacklist array, e.g.:
+#
+# github_blacklist: [dotfiles, username.github.com]
 
 # Twitter
 twitter_user:


### PR DESCRIPTION
I have a few boring repos like my github pages repo and my dotfiles repo, that I want to be able to blacklist in `_config.yml` from showing up in the github aside. They're almost always recently pushed, but aren't really interesting to showcase.

This patch allows an array of repo names to be specified in `_config.yml` under the optional `github_blacklist` key. Any repos that show up there will be omitted from the display.
