### PR TITLE
Extract category_link filter from category_generator.rb plugin

### DIFF
--- a/plugins/category_generator.rb
+++ b/plugins/category_generator.rb
@@ -141,10 +141,7 @@ module Jekyll
     # Returns string
     #
     def category_links(categories)
-      dir = @context.registers[:site].config['category_dir']
-      categories = categories.sort!.map do |item|
-        "<a class='category' href='/#{dir}/#{item.gsub(/_|\P{Word}/, '-').gsub(/-{2,}/, '-').downcase}/'>#{item}</a>"
-      end
+      categories = categories.sort!.map { |c| category_link c }
 
       case categories.length
       when 0
@@ -154,6 +151,17 @@ module Jekyll
       else
         "#{categories[0...-1].join(', ')}, #{categories[-1]}"
       end
+    end
+
+    # Outputs a single category as an <a> link.
+    #
+    #  +category+ is a category string to format as an <a> link
+    #
+    # Returns string
+    #
+    def category_link(category)
+      dir = @context.registers[:site].config['category_dir']
+      "<a class='category' href='/#{dir}/#{category.gsub(/_|\P{Word}/, '-').gsub(/-{2,}/, '-').downcase}/'>#{category}</a>"
     end
 
     # Outputs the post.date as formatted html, with hooks for CSS styling.


### PR DESCRIPTION
Not sure if you can use this, but I found it helpful to extract a `category_link` method from within `category_generator.rb` so I could display a category as a link. I used it to get a [categories index page](https://github.com/dtchepak/davesquared.net/commit/ee4976ca8a6f80220b3c28b6b720f1b79b41b0c7#diff-2). I don't know if others would find this useful, but thought I'd send it through just in case.

Cheers,
David
