### PR TITLE
Remove link rel="canonical"

### DIFF
--- a/.themes/classic/source/_includes/head.html
+++ b/.themes/classic/source/_includes/head.html
@@ -16,8 +16,6 @@
   <meta name="MobileOptimized" content="320">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  {% capture canonical %}{{ site.url }}{% if site.permalink contains '.html' %}{{ page.url }}{% else %}{{ page.url | remove:'index.html' | strip_slash }}{% endif %}{% endcapture %}
-  <link rel="canonical" href="{{ canonical }}">
   <link href="{{ root_url }}/favicon.png" rel="icon">
   <link href="{{ root_url }}/stylesheets/screen.css" media="screen, projection" rel="stylesheet" type="text/css">
   <script src="{{ root_url }}/javascripts/modernizr-2.0.js"></script>


### PR DESCRIPTION
This is broken for categories (they are missing a slash), and
it is also inconsistent with the internal linking: The permalinks
have a trailing slash, whereas the canonical URLs don't.

It is probably easiest to just remove this.

---

Google is actually ignoring this:
On https://www.google.com/search?ie=utf-8&q=Octopress+2.0+Surfaces the first hit has a trailing slash, but the canonical URL in the source doesn't.

I say instead of fixing this, we should just remove it -- the value to be had from this feature is rather little.
