### PR TITLE
In set_root_dir, update the site URL as well

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -282,6 +282,7 @@ task :set_root_dir, :dir do |t, args|
       f.write compass_config
     end
     jekyll_config = IO.read('_config.yml')
+    jekyll_config.sub!(/^url:\s*(.+?)\/*$/, "url: \\1#{dir}")
     jekyll_config.sub!(/^destination:.+$/, "destination: public#{dir}")
     jekyll_config.sub!(/^subscribe_rss:\s*\/.+$/, "subscribe_rss: #{dir}/atom.xml")
     jekyll_config.sub!(/^root:.*$/, "root: /#{dir.sub(/^\//, '')}")


### PR DESCRIPTION
Else a lot of absolute links are broken. This caused me some grief because
initially I wasn't sure whether the root would be automatically appended to
the site URL or not -- but since that's apparently not the case, we should
have the site URL be http://www.example.com/blog (if the root is "blog").
