### PR TITLE
Added categories in xml feed to support feedburner Socialize hashtag feature

### DIFF
--- a/.themes/classic/source/atom.xml
+++ b/.themes/classic/source/atom.xml
@@ -21,6 +21,7 @@ layout: nil
     <link href="{{ site.url }}{{ post.url }}"/>
     <updated>{{ post.date | date_to_xmlschema }}</updated>
     <id>{{ site.url }}{{ post.id }}</id>
+    {% for category in post.categories %}<category term="{{ category }}" />{% endfor %}
     <content type="html"><![CDATA[{{ post.content | expand_urls: site.url | cdata_escape }}]]></content>
   </entry>
   {% endfor %}


### PR DESCRIPTION
added &lt;category term="***"/&gt; into entry
I've add this change to support feedburner Socialize hash tag feature(it takes this categories and add it as a hashtags in tweets) 
