### PR TITLE
multi-line matching for pullquotes.

### DIFF
--- a/plugins/pullquote.rb
+++ b/plugins/pullquote.rb
@@ -32,7 +32,7 @@ module Jekyll
 
     def render(context)
       output = super
-      if output.join =~ /\{"\s*(.+)\s*"\}/
+      if output.join =~ /\{"\s*(.+)\s*"\}/m
         #@quote = $1
         @quote = RubyPants.new($1).to_html
         #@quote = CGI.escape($1)


### PR DESCRIPTION
Make pullquote matching work multiline. So
 {% pullquote %}
this is a para {" with a
multi-line "} pullquote
{% endpullquote %}

will work.
