### PR TITLE
Comments link still visible on home page for excerpts even when comments for that post are set to false

### DIFF
--- a/source/_includes/article.html
+++ b/source/_includes/article.html
@@ -8,7 +8,7 @@
     {% unless page.meta == false %}
       <p class="meta">
         {% include post/date.html %}{{ time }}
-        {% if site.disqus_short_name and page.comments != false and site.disqus_show_comment_count == true %}
+        {% if site.disqus_short_name and page.comments != false and post.comments != false and site.disqus_show_comment_count == true %}
          | <a href="{% if index %}{{ root_url }}{{ post.url }}{% endif %}#disqus_thread">Comments</a>
         {% endif %}
       </p>


### PR DESCRIPTION
I was having an issue where I was trying to enable comments for some posts and disable them for others. On the home page, when I would have comments set to true for one post and false for another, both blog posts would have the comments link next to the date.

I found that by adding `post.comments != false` to the conditional statement in `article.html`, the comments link would be removed on excerpt style pages when comments are set to false.
