### PR TITLE
Pipes feed content through excerpt filter

### DIFF
--- a/.themes/classic/source/_includes/custom/category_feed.xml
+++ b/.themes/classic/source/_includes/custom/category_feed.xml
@@ -21,7 +21,7 @@ layout: nil
     <link href="{{ site.url }}{{ post.url }}"/>
     <updated>{{ post.date | date_to_xmlschema }}</updated>
     <id>{{ site.url }}{{ post.id }}</id>
-    <content type="html"><![CDATA[{{ post.content | expand_urls: site.url | markdownify | cdata_escape }}]]></content>
+    <content type="html"><![CDATA[{{ post.content | excerpt | expand_urls: site.url | markdownify | cdata_escape }}]]></content>
   </entry>
   {% endfor %}
 </feed>

--- a/.themes/classic/source/atom.xml
+++ b/.themes/classic/source/atom.xml
@@ -21,7 +21,7 @@ layout: nil
     <link href="{{ site.url }}{{ post.url }}"/>
     <updated>{{ post.date | date_to_xmlschema }}</updated>
     <id>{{ site.url }}{{ post.id }}</id>
-    <content type="html"><![CDATA[{{ post.content | expand_urls: site.url | cdata_escape }}]]></content>
+    <content type="html"><![CDATA[{{ post.content | excerpt | expand_urls: site.url | cdata_escape }}]]></content>
   </entry>
   {% endfor %}
 </feed>


### PR DESCRIPTION
When posts are enabled with the excerpt filter (using <!-- more -->)
the front page shows an abbreviated content but the feed shows the full
list.

This updates the main atom feed so that it shows the same abbreviated
content if it is available. A similar change is updated for the categories
as well.

Fixes issue #431
