### PR TITLE
Github -> GitHub (capitalization)

### DIFF
--- a/.themes/classic/source/_includes/asides/github.html
+++ b/.themes/classic/source/_includes/asides/github.html
@@ -1,11 +1,11 @@
 {% if site.github_user %}
 <section>
-  <h1>Github Repos</h1>
+  <h1>GitHub Repos</h1>
   <ul id="gh_repos">
     <li class="loading">Status updating...</li>
   </ul>
   {% if site.github_show_profile_link %}
-  <a href="https://github.com/{{site.github_user}}">@{{site.github_user}}</a> on Github
+  <a href="https://github.com/{{site.github_user}}">@{{site.github_user}}</a> on GitHub
   {% endif %}
   <script type="text/javascript">
     $.domReady(function(){


### PR DESCRIPTION
Only the GitHub logo is in lower case. Written out, it's always GitHub.
