### PR TITLE
RTL Support

### DIFF
--- a/.themes/classic/sass/custom/_styles.scss
+++ b/.themes/classic/sass/custom/_styles.scss
@@ -1,2 +1,3 @@
 // This File is imported last, and will override other styles in the cascade
 // Add styles here to make changes without digging in too much
+.rtl { direction: rtl }

--- a/.themes/classic/source/_layouts/default.html
+++ b/.themes/classic/source/_layouts/default.html
@@ -1,10 +1,13 @@
 {% capture root_url %}{{ site.root | strip_slash }}{% endcapture %}
 {% include head.html %}
+{% if post.rtl or page.rtl %}
+  {% assign rtl = true %}
+{% endif %}
 <body {% if page.body_id %} id="{{ page.body_id }}" {% endif %} {% if page.sidebar == false %} class="no-sidebar" {% endif %} {% if page.sidebar == 'collapse' or site.sidebar == 'collapse' %} class="collapse-sidebar sidebar-footer" {% endif %}>
   <header role="banner">{% include header.html %}</header>
   <nav role="navigation">{% include navigation.html %}</nav>
   <div id="main">
-    <div id="content">
+    <div id="content" {% if rtl %} class="rtl" {% endif %}>
       {{ content | expand_urls: root_url }}
     </div>
   </div>


### PR DESCRIPTION
Based on our Twitter exchange on RTL support:

You suggested using the `body_id: rtl` attribute, but this would cause the entire page to be RTL.
I wanted only the content of the page. 
Adding `rtl: true` in the yaml front-matter will give the content the `rtl` class, which is then set to RTL direction with the scss.
