### PR TITLE
Raise RuntimeError when gist is unavailable - #437

### DIFF
--- a/plugins/gist_tag.rb
+++ b/plugins/gist_tag.rb
@@ -82,7 +82,7 @@ module Jekyll
       https.verify_mode = OpenSSL::SSL::VERIFY_NONE
       request           = Net::HTTP::Get.new raw_uri.request_uri
       data              = https.request request
-      if data.code != 200
+      if Integer(data.code) != 200
           raise RuntimeError, "Gist replied with #{data.code} for #{gist_url}"
       end
       data              = data.body


### PR DESCRIPTION
This commit raises RuntimeError if gist responds with a HTTP error preventing the error page from being included into generated text (#437).
