### PR TITLE
Added enable-able MathJax.

### DIFF
--- a/.themes/classic/source/_includes/head.html
+++ b/.themes/classic/source/_includes/head.html
@@ -24,6 +24,8 @@
   <script src="{{ root_url }}/javascripts/ender.js"></script>
   <script src="{{ root_url }}/javascripts/octopress.js" type="text/javascript"></script>
   <link href="{{ site.subscribe_rss }}" rel="alternate" title="{{site.title}}" type="application/atom+xml">
+  {% if site.mathjax %}<script type="text/javascript"
+  src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>{% endif %}
   {% include custom/head.html %}
   {% include google_analytics.html %}
 </head>

--- a/_config.yml
+++ b/_config.yml
@@ -35,6 +35,7 @@ code_dir: downloads/code
 category_dir: blog/categories
 markdown: rdiscount
 pygments: false # default python pygments have been replaced by pygments.rb
+mathjax: false # switch on to enable MathJax in-browser LaTeX markup
 
 paginate: 10          # Posts per page on the blog index
 pagination_dir: blog  # Directory base for pagination URLs eg. /blog/page/2/

--- a/plugins/MathJax.rb
+++ b/plugins/MathJax.rb
@@ -1,0 +1,22 @@
+module Jekyll
+  class MathJaxBlockTag < Liquid::Tag
+    def render(context)
+      '<script type="math/tex; mode=display">'
+    end
+  end
+class MathJaxInlineTag < Liquid::Tag
+    def render(context)
+      '<script type="math/tex">'
+    end
+  end
+class MathJaxEndTag < Liquid::Tag
+    def render(context)
+      '</script>'
+    end
+  end
+end
+
+Liquid::Template.register_tag('math', Jekyll::MathJaxBlockTag)
+Liquid::Template.register_tag('m', Jekyll::MathJaxInlineTag)
+Liquid::Template.register_tag('endmath', Jekyll::MathJaxEndTag)
+Liquid::Template.register_tag('em', Jekyll::MathJaxEndTag)


### PR DESCRIPTION
Word.

It works. You use the following stuff to do it:

```
Inline mathjax: {% m %}\LATEX{% em %}

Paragraph-level mathjax:

{% math %}\LATEX{% endmath %}
```

(Don't quote me on the capitalization of the \LATEX command).
