### PR TITLE
Google Analytics IP Anonymization

### DIFF
--- a/.themes/classic/source/_includes/google_analytics.html
+++ b/.themes/classic/source/_includes/google_analytics.html
@@ -2,8 +2,11 @@
   <script type="text/javascript">
     var _gaq = _gaq || [];
     _gaq.push(['_setAccount', '{{ site.google_analytics_tracking_id }}']);
+    {% if site.google_analytics_anonymize_ip %}
+    _gaq.push (['_gat._anonymizeIp']);
+    {% endif %}
     _gaq.push(['_trackPageview']);
-
+    
     (function() {
       var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
       ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';

--- a/_config.yml
+++ b/_config.yml
@@ -94,6 +94,7 @@ disqus_show_comment_count: false
 
 # Google Analytics
 google_analytics_tracking_id:
+google_analytics_anonymize_ip: true
 
 # Facebook Like
 facebook_like: false


### PR DESCRIPTION
Hey there, 

I just added a configuration option to anonymize the IP before it gets sent to Google and adjusted the include file. Would be nice if you could add this to Octopress :)

For the details please have a look at:
http://code.google.com/apis/analytics/docs/gaJS/gaJSApi_gat.html#_gat._anonymizeIp
