### PR TITLE
Blockquote: Print author if no other information is provided (#461)

### DIFF
--- a/plugins/blockquote.rb
+++ b/plugins/blockquote.rb
@@ -38,7 +38,7 @@ module Jekyll
         if $1 =~ /([^,]+),([^,]+)/
           @by = $1
           @title = $2.titlecase
-        else
+        elsif markup =~ Author
           @by = $1
         end
       end


### PR DESCRIPTION
According to http://octopress.org/docs/plugins/blockquote/, a quote can have an author without further information, e.g.

```
{% blockquote Nelson Mandela %}
It always seems impossible until it is done.
{% endblockquote %}
```

However, the author of the above quote is not printed with the current Octopress master.

This feature was added in 967eeb46e8f9bb25a382c52f1f36de59b8f0d1cb.

I've created already Octopress issue #461 for this problem.

This change fixed it for me.
