### PR TITLE
Don't display comments link for post excerpts on index page when comments for that post are set to false

### DIFF
--- a/.themes/classic/source/_includes/article.html
+++ b/.themes/classic/source/_includes/article.html
@@ -8,7 +8,7 @@
     {% unless page.meta == false %}
       <p class="meta">
         {% include post/date.html %}{{ time }}
-        {% if site.disqus_short_name and page.comments != false and site.disqus_show_comment_count == true %}
+        {% if site.disqus_short_name and page.comments != false and post.comments != false and site.disqus_show_comment_count == true %}
          | <a href="{% if index %}{{ root_url }}{{ post.url }}{% endif %}#disqus_thread">Comments</a>
         {% endif %}
       </p>


### PR DESCRIPTION
This is the same as [pull request 425](https://github.com/imathis/octopress/pull/425/files) which was merged into the site branch. This is the same change into the master branch.
