### PR TITLE
Updated dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
   gem 'RedCloth', '~> 4.2.9'
   gem 'haml', '~> 3.1.4'
   gem 'compass', '~> 0.12.1'
-  gem 'rubypants'
+  gem 'rubypants', '~> 0.2.0'
   gem 'rb-fsevent', '~> 0.9.0'
   gem 'stringex', '~> 1.3.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,6 @@ DEPENDENCIES
   rake (~> 0.9.2)
   rb-fsevent (~> 0.9.0)
   rdiscount (~> 1.6.8)
-  rubypants
+  rubypants (~> 0.2.0)
   sinatra (~> 1.3.2)
   stringex (~> 1.3.2)


### PR DESCRIPTION
This series of patches brings all of Octopress' dependencies to the current versions. Additionally I did some cleanup of the Gemfile and restricted all versions with `~>`. This looks a lot cleaner now and should cause no problems. I also tested Jekyll in combination with Liquid 2.3.0.

Feel free to share your thoughts on this one or just cherry pick some of the commits.
