### PR TITLE
Local rsync deployment

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,9 +6,9 @@ require "stringex"
 # Be sure your public key is listed in your server's ~/.ssh/authorized_keys file
 ssh_user       = "user@domain.com"
 ssh_port       = "22"
-document_root  = "~/website.com/"
+document_root  = "/srv/http/deriamis.net/htdocs/"
 rsync_delete   = true
-deploy_default = "rsync"
+deploy_default = "local"
 
 # This will be configured for you when you run config_deploy
 deploy_branch  = "gh-pages"


### PR DESCRIPTION
I wanted to put the code on the same server I'll be deploying from (it's the master) and some other people might want this as well. I added a Rake task that basically modifies the original remote rsync task to push to a local directory. There's probably a better way to do this by integrating it into the original task - but I don't really know ruby and it's simple enough this way.
