### PR TITLE
Updated GitHub repos list to use GitHub Api v3

### DIFF
--- a/.themes/classic/source/javascripts/github.js
+++ b/.themes/classic/source/javascripts/github.js
@@ -3,7 +3,7 @@ var github = (function(){
     var i = 0, fragment = '', t = $(target)[0];
 
     for(i = 0; i < repos.length; i++) {
-      fragment += '<li><a href="'+repos[i].url+'">'+repos[i].name+'</a><p>'+repos[i].description+'</p></li>';
+      fragment += '<li><a href="'+repos[i].html_url+'">'+repos[i].name+'</a><p>'+repos[i].description+'</p></li>';
     }
     t.innerHTML = fragment;
   }


### PR DESCRIPTION
[GitHub are retiring Api v2](https://github.com/blog/1090-github-api-moving-on) so here is an Api v3 version of the repos list.
