### PR TITLE
Adds gemset to .rvmrc file

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm use 1.9.2
+rvm use 1.9.2@octopress


### PR DESCRIPTION
That way the default gemset isn't messed with when installing the bundle for octopress. I feel like this is something most developers end up doing anyways on their local repo so I figured I would ask if y'all wanted to canonize it. If the octopress gemset isn't created, it will give a message warning as such and that it will use the default instead. I feel this is a good fall back.
