### PR TITLE
UTF-8 Support in Backtick Code

### DIFF
--- a/plugins/backtick_code_block.rb
+++ b/plugins/backtick_code_block.rb
@@ -10,7 +10,7 @@ module BacktickCodeBlock
     @lang = nil
     @url = nil
     @title = nil
-    input.force_encoding('UTF-8')
+    input.encode!("UTF-8")
     input.gsub(/^`{3} *([^\n]+)?\n(.+?)\n`{3}/m) do
       @options = $1 || ''
       str = $2


### PR DESCRIPTION
In response to my Issue, #550, where Backtick Code Block dies on UTF-8.

In my fix, I force the input to Backtick Code Block to be converted to UTF-8. This prevents inconsistencies in encoding, which are fatal to the site generation process, and really undesirable. This may not be the perfect fix at all, but it fixes a major headache.
