### PR TITLE
Fix pullquote regex to grab multi-line pullquotes

### DIFF
--- a/plugins/pullquote.rb
+++ b/plugins/pullquote.rb
@@ -32,7 +32,7 @@ module Jekyll
 
     def render(context)
       output = super
-      if output.join =~ /\{"\s*(.+)\s*"\}/
+      if output.join =~ /\{"\s*(.+?)\s*"\}/m
         #@quote = $1
         @quote = RubyPants.new($1).to_html
         #@quote = CGI.escape($1)


### PR DESCRIPTION
Before this change, pullquote.rb only matched pullquotes if they were on the same line.

I switched the mode to multiline (with /m) and made the match non-greedy and now it matches multi-line pullquotes.

E.g.

``` markdown
{% pullquote %}
I wrap my lines at a short number of characters {" to make
things more readable "} and I always like my pullquotes to
reflect that.
{% endpullquote %}
```

I wrote test case posts and it all seems to check out (it also doesn't seem to make malformed pullquotes have weird behavior).  You can find them here:  jtratner/octopress@c658978d56fed160519289b5d5272b04faae2407 (and they are generated to html to boot).

It doesn't change any behavior that previously worked, nor will it gobble things up.
