### PR TITLE
weird quote character in the 404 page

### DIFF
--- a/.themes/classic/source/404.markdown
+++ b/.themes/classic/source/404.markdown
@@ -3,6 +3,6 @@ layout: page
 title: Page Not Found
 ---
 
-Oops, I couldn’t find that page! Sorry about that.
+Oops, I couldn't find that page! Sorry about that.
 
 Maybe try the search box (top right), or look through the [archives](/archives)?


### PR DESCRIPTION
I found the single quote in the 404 page is not the common single quote we usually see. Here is a commit to fix that.
