### PR TITLE
Sitemap exclude file list

### DIFF
--- a/plugins/sitemap_generator.rb
+++ b/plugins/sitemap_generator.rb
@@ -46,7 +46,7 @@ module Jekyll
   SITEMAP_FILE_NAME = "sitemap.xml"
 
   # Any files to exclude from being included in the sitemap.xml
-  EXCLUDED_FILES = ["atom.xml, 404.html"]
+  EXCLUDED_FILES = ["atom.xml", "404.markdown"]
 
   # Any files that include posts, so that when a new post is added, the last
   # modified date of these pages should take that into account


### PR DESCRIPTION
#569 is not fixed.
1.  The double quote isn't correctly used;
2.  we need to use `404.markdown` to make it take effect.

Here is the commit to fix the issue.
