### PR TITLE
Control front page posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,6 +53,10 @@ default_asides: [asides/recent_posts.html, asides/github.html, asides/twitter.ht
 # post_asides:
 # page_asides:
 
+#control which posts show on the front page  
+front_page_categories: [] # A list of categories for the front page
+front_page_categories_op : 'hide' # Whether to show or hide the list of categories from front_page_categories
+
 # ----------------------- #
 #   3rd Party Settings    #
 # ----------------------- #

--- a/plugins/pagination.rb
+++ b/plugins/pagination.rb
@@ -31,6 +31,15 @@ module Jekyll
     #                   "next_page" => <Number> }}
     def paginate(site, page)
       all_posts = site.site_payload['site']['posts']
+      
+      # show / hide some categories
+      op = (site.config['front_page_categories_op'] == 'hide') ? 'delete_if' : 'keep_if';
+      if site.config['front_page_categories'].kind_of?(Array)
+        all_posts.send(op) do |post|
+          (site.config['front_page_categories'] & post.categories).size == 1
+        end
+      end
+      
       pages = Pager.calculate_pages(all_posts, site.config['paginate'].to_i)
       page_dir = page.destination('').sub(/\/[^\/]+$/, '')
       page_dir_config = site.config['pagination_dir']


### PR DESCRIPTION
Gives control over which posts show / are hidden from the front page based on categories.

Examples : http://www.donothackcore.com/blog/2012/05/10/recipe-hiding-posts-from-the-octopress-front-page/
