### PR TITLE
Add ".git" folder into the RakeTask :copydot 's exclude list

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,10 +8,10 @@ ssh_user       = "user@domain.com"
 ssh_port       = "22"
 document_root  = "~/website.com/"
 rsync_delete   = true
-deploy_default = "push"
+deploy_default = "rsync"
 
 # This will be configured for you when you run config_deploy
-deploy_branch  = "master"
+deploy_branch  = "gh-pages"
 
 ## -- Misc Configs -- ##
 


### PR DESCRIPTION
In my case, I need to add posts from several git submodules into the folder `source/_posts` . But the rake task failed because there is a .git folder. So I looked into the Rakefile and found I can add it into the exclued list.
