### PR TITLE
Use a more portable way to create .nojekyll file when deploying to github pages.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -295,7 +295,7 @@ multitask :push do
     puts "\n## copying #{public_dir} to #{deploy_dir}"
     cp_r "#{public_dir}/.", deploy_dir
     cd "#{deploy_dir}" do
-      system "touch .nojekyll"
+      File.new(".nojekyll", "w").close
       system "git add ."
       system "git add -u"
       message = "Site updated at #{Time.now.utc}"


### PR DESCRIPTION
This is trying to fix #573 in a more portable way. The previous solution, e81e1c828933df7f72b534adae4f60d897e004e3, won't work on Windows since there is no "touch" command there.
