### PR TITLE
Fix drop down nav on Windows Phone (Issue #564)

### DIFF
--- a/.themes/classic/source/javascripts/octopress.js
+++ b/.themes/classic/source/javascripts/octopress.js
@@ -1,16 +1,26 @@
 function getNav() {
-  var mobileNav = $('nav[role=navigation] fieldset[role=search]').after('<fieldset class="mobile-nav"></fieldset>').next().append('<select></select>');
-  mobileNav.children('select').append('<option value="">Navigate&hellip;</option>');
+  var select = '<select><option value="">Navigate&hellip;</option>';
+  
   $('ul[role=main-navigation]').addClass('main-navigation');
-  $('ul.main-navigation a').each(function(link) {
-    mobileNav.children('select').append('<option value="'+link.href+'">&raquo; '+link.text+'</option>');
-  });
-  $('ul.subscription a').each(function(link) {
-    mobileNav.children('select').append('<option value="'+link.href+'">&raquo; '+link.text+'</option>');
-  });
-  mobileNav.children('select').bind('change', function(event) {
+  
+  var addOption = function(link) {
+    select += '<option value="' + link.href + '">&raquo; ' + link.innerText + '</option>';
+  };
+  
+  $('ul.main-navigation a').each(addOption);
+  $('ul.subscription a').each(addOption);
+  
+  select += '</select>';
+  
+  var selectElem = $(select);
+  
+  selectElem.bind('change', function(event) {
     if (event.target.value) { window.location.href = event.target.value; }
   });
+  
+  $('nav[role=navigation] fieldset[role=search]')
+      .after('<fieldset class="mobile-nav"></fieldset>')
+      .next().append(selectElem);
 }
 
 function addSidebarToggler() {


### PR DESCRIPTION
Two fixes to the dropdown nav code to get it working on windows phone:
1. build the `select` as a big string, then append at the end
2. use `link.innerText` instead of `link.text`

This also fixes the nav drop down on IE9.
