### PR TITLE
Adding .powrc to allow RVM to work when POW is updated to version 0.4.0 ...

### DIFF
--- a/.powrc
+++ b/.powrc
@@ -1,0 +1,5 @@
+if [ -f "$rvm_path/scripts/rvm" ] && [ -f ".rvmrc" ] ; then
+  source "$rvm_path/scripts/rvm"
+  source ".rvmrc"
+fi
+  


### PR DESCRIPTION
...and beyond.

Support for automatically handling .rvmrc files in projects is being deprecated in
POW version 0.4.0 and beyond. RVM will still work but project will need to have a
.powrc file that detects the presence of and then loads RVM.

The code in the .powrc could also be in the .powenv file, however the .powrc loads
first and is the configuration file recommended for inclusion in version control.
