### PR TITLE
[minor bugfix] 2.1: refer to page_meta.html rather than page-meta.html

### DIFF
--- a/.themes/classic/source/_layouts/page.html
+++ b/.themes/classic/source/_layouts/page.html
@@ -13,7 +13,7 @@ layout: default
   {{ content }}
   {% unless page.footer == false %}
     <footer>
-      <p class="meta">{% include post/meta.html %}{% include custom/page-meta.html %}</p>
+      <p class="meta">{% include post/meta.html %}{% include custom/page_meta.html %}</p>
       {% unless page.sharing == false %}
         {% include post/sharing.html %}
       {% endunless %}


### PR DESCRIPTION
the default _layouts/page.html refers to _includes/custom/page-meta.html. This results in an error---the file's actual name is page_meta.html. ;)
