### PR TITLE
Exclude Vim swapfiles when deploying dotfiles.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -225,7 +225,7 @@ end
 
 desc "copy dot files for deployment"
 task :copydot, :source, :dest do |t, args|
-  FileList["#{args.source}/**/.*"].exclude("**/.", "**/..", "**/.DS_Store", "**/._*").each do |file|
+  FileList["#{args.source}/**/.*"].exclude("**/.", "**/..", "**/.DS_Store", "**/._*", "**/.*.swp").each do |file|
     cp_r file, file.gsub(/#{args.source}/, "#{args.dest}") unless File.directory?(file)
   end
 end


### PR DESCRIPTION
Does what it says on the tin. Thanks for Octopress!
