### PR TITLE
Allow customizing new post's slug

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -90,12 +90,12 @@ end
 
 # usage rake new_post[my-new-post] or rake new_post['my new post'] or rake new_post (defaults to "new-post")
 desc "Begin a new post in #{source_dir}/#{posts_dir}"
-task :new_post, :title do |t, args|
+task :new_post, :title, :slug do |t, args|
   raise "### You haven't set anything up yet. First run `rake install` to set up an Octopress theme." unless File.directory?(source_dir)
   mkdir_p "#{source_dir}/#{posts_dir}"
   args.with_defaults(:title => 'new-post')
-  title = args.title
-  filename = "#{source_dir}/#{posts_dir}/#{Time.now.strftime('%Y-%m-%d')}-#{title.to_url}.#{new_post_ext}"
+  title, slug = args.title, args.slug
+  filename = "#{source_dir}/#{posts_dir}/#{Time.now.strftime('%Y-%m-%d')}-#{slug ? slug.to_url : title.to_url}.#{new_post_ext}"
   if File.exist?(filename)
     abort("rake aborted!") if ask("#{filename} already exists. Do you want to overwrite?", ['y', 'n']) == 'n'
   end


### PR DESCRIPTION
It's convenient to be able to customize the slug for the post in some context.
For example, when post title is in Chinese, pinyin(got from `to_url` of `Stringex`) is not appropriate to be used as the slug which will finally be the url of the post when deployed, because it's almost always meaningless, even to a Chinese. With this option available, one can manually translate the title and use it as the slug.
