### PR TITLE
Fix the `Index` page's description error.

### DIFF
--- a/.themes/classic/source/_includes/head.html
+++ b/.themes/classic/source/_includes/head.html
@@ -7,7 +7,7 @@
   <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
   <meta name="author" content="{{ site.author }}">
 
-  {% capture description %}{% if page.description %}{{ page.description }}{% else %}{{ content | raw_content }}{% endif %}{% endcapture %}
+  {% capture description %}{% if page.description %}{{ page.description }}{% else if site.description %}{{ site.description }}{% else %}{{content|raw_content}}{% endif %}{% endcapture %}
   <meta name="description" content="{{ description | strip_html | condense_spaces | truncate:150 }}">
   {% if page.keywords %}<meta name="keywords" content="{{ page.keywords }}">{% endif %}
 


### PR DESCRIPTION
In the past, when you modify the `description` in the `_config.yml`, The `Index` Page can not show the description which is configured in the `_config.yml`.Now `Index` page can show description correct in the `meta` tag.
