### PR TITLE
Directory tag

### DIFF
--- a/plugins/directory.rb
+++ b/plugins/directory.rb
@@ -1,0 +1,117 @@
+# Title: Dynamic directories for Jekyll
+# Author: Tommy Sullivan http://superawesometommy.com, Robert Park http://exolucere.ca
+# Description: The directory tag lets you iterate over files at a particular path. If files conform to the standard Jekyll format, YYYY-MM-DD-file-title, then those attributes will be populated on the yielded file object. The `forloop` object maintains [its usual context](http://wiki.shopify.com/UsingLiquid#For_loops).
+#
+# Syntax:
+#
+#   {% directory path: path/from/source [reverse] [exclude] %}
+#     {{ file.url }}
+#     {{ file.name }}
+#     {{ file.date }}
+#     {{ file.slug }}
+#     {{ file.title }}
+#   {% enddirectory %}
+#
+# Options:
+#
+# - `reverse` - Defaults to 'false', ordering files the same way `ls` does: 0-9A-Za-z.
+# - `exclude` - Defaults to '.html$', a Regexp of files to skip.
+#
+# File Attributes:
+#
+# - `url` - The absolute path to the published file
+# - `name` - The basename
+# - `date` - The date extracted from the filename, otherwise the file's creation time
+# - `slug` - The basename with date and extension removed
+# - `title` - The titlecase'd slug
+#
+
+require './plugins/titlecase.rb'
+
+module Jekyll
+
+  class DirectoryTag < Liquid::Block
+    include Convertible
+
+    MATCHER = /^(.+\/)*(\d+-\d+-\d+)-(.*)(\.[^.]+)$/
+
+    attr_accessor :content, :data
+
+    def initialize(tag_name, markup, tokens)
+      attributes = {}
+
+      # Parse parameters
+      markup.scan(Liquid::TagAttributes) do |key, value|
+        attributes[key] = value
+      end
+
+      @path     = attributes['path']   || '.'
+      @exclude  = Regexp.new(attributes['exclude'] || '.html$', Regexp::EXTENDED | Regexp::IGNORECASE)
+      @rev      = attributes['reverse'].nil?
+
+      super
+    end
+
+    def render(context)
+      context.registers[:directory] ||= Hash.new(0)
+
+      source_dir = context.registers[:site].source
+      directory_files = File.join(source_dir, @path, "*")
+
+      files = Dir.glob(directory_files).reject{|f| f =~ @exclude }
+      files.sort! {|x,y| @rev ? x <=> y : y <=> x }
+
+      length = files.length
+      result = []
+
+      context.stack do
+        files.each_with_index do |filename, index|
+          basename = File.basename(filename)
+
+          filepath  = [@path, basename] - ['.']
+          path = filepath.join '/'
+          url  = '/' + filepath.join('/')
+
+          m, cats, date, slug, ext = *basename.match(MATCHER)
+
+          if m
+            date = Time.parse(date)
+            ext = ext
+            slug = slug
+          else
+            date = File.ctime(filename)
+            ext = basename[/\.[a-z]+$/, 0]
+            slug = basename.sub(ext, '')
+          end
+
+          context['file'] = {
+            'title' => slug.titlecase,
+            'date' => date,
+            'name' => basename,
+            'slug' => slug,
+            'url' => url
+          }
+
+          context['forloop'] = {
+            'name' => 'directory',
+            'length' => length,
+            'index' => index + 1,
+            'index0' => index,
+            'rindex' => length - index,
+            'rindex0' => length - index - 1,
+            'first' => (index == 0),
+            'last' => (index == length - 1)
+          }
+
+          result << render_all(@nodelist, context)
+        end
+      end
+      result
+    end
+
+  end
+
+end
+
+Liquid::Template.register_tag('directory', Jekyll::DirectoryTag)
+

--- a/source/docs/plugins/directory-tag/index.markdown
+++ b/source/docs/plugins/directory-tag/index.markdown
@@ -1,0 +1,64 @@
+---
+layout: page
+title: "Directory Tag"
+date: 2012-07-28 00:18
+sidebar: false
+footer: false
+---
+
+The directory tag lets you iterate over files at a particular path. If files conform to the standard Jekyll format, YYYY-MM-DD-file-title, then those attributes will be populated on the yielded file object. The `forloop` object maintains [its usual context](http://wiki.shopify.com/UsingLiquid#For_loops).
+
+#### Syntax
+
+{% raw %}
+    {% directory path: path/from/source [reverse] [exclude] %}
+      {{ file.url }}
+      {{ file.name }}
+      {{ file.date }}
+      {{ file.slug }}
+      {{ file.title }}
+    {% enddirectory %}
+{% endraw %}
+
+##### Options:
+
+- `reverse` - Defaults to 'false', ordering files the same way `ls` does: 0-9A-Za-z.
+- `exclude` - Defaults to '.html$', a Regexp of files to skip.
+
+##### File Attributes:
+
+- `url` - The absolute path to the published file
+- `name` - The basename
+- `date` - The date extracted from the filename, otherwise the file's creation time
+- `slug` - The basename with date and extension removed
+- `title` - The titlecase'd slug
+
+#### Example, images
+
+The social icons in this project:
+
+{% raw %}
+    {% directory path: images/icon exclude: google %}
+      <img src="{{ file.url }}" alt="{{ file.title }}" datetime="{{ file.date | date_to_xmlschema }}" />
+    {% enddirectory %}
+{% endraw %}
+
+#### Output
+
+{% directory path: images/icon exclude: google %}
+  <img src="{{ file.url }}" alt="{{ file.title }}" datetime="{{ file.date | date_to_xmlschema }}" />
+{% enddirectory %}
+
+#### Example, downloads 
+
+The fonts in this project:
+
+{% raw %}
+    {% directory path: fonts %}<a href="{{ file.url }}" >{{ file.name }}</a>{% unless forloop.last %}, {% endunless %}{% enddirectory %}
+{% endraw %}
+
+#### Output
+
+{% directory path: fonts %}<a href="{{ file.url }}" >{{ file.name }}</a>{% unless forloop.last %}, {% endunless %}{% enddirectory %}
+
+[&laquo; Plugins page](/docs/plugins)

--- a/source/docs/plugins/index.markdown
+++ b/source/docs/plugins/index.markdown
@@ -16,6 +16,7 @@ Octopress ships with the following plugins. Many have been written specially for
 - [Gist Tag](/docs/plugins/gist-tag/) - *automatically downloads and embeds Github gists*
 - [jsFiddle](/docs/plugins/jsfiddle-tag/) - *embeds code from jsFiddle*
 - [Image Tag](/docs/plugins/image-tag/) - *easily post images with class names and titles*
+- [Directory Tag](/docs/plugins/directory-tag/) - *dynamically generate image galleries and other lists of files*
 - [Render Partial](/docs/plugins/render-partial/) - *insert any file into another post or page*
 - [Block Quote](/docs/plugins/blockquote/) - *generate beautiful, semantic block quotes*
 - [Pull Quote](/docs/plugins/pullquote/) - *generate CSS only pull quotes &mdash; no duplicate data, no javascript*


### PR DESCRIPTION
The directory tag lets you iterate over files at a particular path. If files conform to the standard Jekyll format, YYYY-MM-DD-file-title, then those attributes will be populated on the yielded file object. The `forloop` object maintains [its usual context](http://wiki.shopify.com/UsingLiquid#For_loops).
#### Syntax

``` liquid
{% directory path: path/from/source [reverse] [exclude] %}
  {{ file.url }}
  {{ file.name }}
  {{ file.date }}
  {{ file.slug }}
  {{ file.title }}
{% enddirectory %}
```
##### Options:
- `reverse` - Defaults to 'false', ordering files the same way `ls` does: 0-9A-Za-z.
- `exclude` - Defaults to '.html$', a Regexp of files to skip.
##### File Attributes:
- `url` - The absolute path to the published file
- `name` - The basename
- `date` - The date extracted from the filename, otherwise the file's creation time
- `slug` - The basename with date and extension removed
- `title` - The titlecase'd slug
