### PR TITLE
Proposed fix for Issue #662 - Title and link overlap on code_block

### DIFF
--- a/.themes/classic/sass/base/_layout.scss
+++ b/.themes/classic/sass/base/_layout.scss
@@ -189,8 +189,3 @@ body.sidebar-footer {
     ul, ol { margin-left: 0; }
   }
 }
-
-#figfooter {
-  @include border-top-radius(0px);
-  @include border-bottom-radius(5px);
-}

--- a/.themes/classic/sass/partials/_syntax.scss
+++ b/.themes/classic/sass/partials/_syntax.scss
@@ -226,6 +226,10 @@ figure.code {
   }
 }
 
+.figfooter {
+  border-radius: 0px 0px 5px 5px !important;
+}
+
 .code-title {
   text-align: center;
   font-size: 13px;

--- a/plugins/code_block.rb
+++ b/plugins/code_block.rb
@@ -93,9 +93,9 @@ module Jekyll
         source += "#{tableize_code(code.lstrip.rstrip.gsub(/</,'&lt;'))}"
       end
       if !@linkTitle.nil?
-        source += "<figcaption id='figfooter'><a href='#{@linkUrl}'>#{@linkTitle}</a></figcaption>"
+        source += "<figcaption class='figfooter'><a href='#{@linkUrl}'>#{@linkTitle}</a></figcaption>"
       elsif !@linkUrl.nil?
-        source += "<figcaption id='figfooter'><a href='#{@linkUrl}'>link</a></figcaption>"
+        source += "<figcaption class='figfooter'><a href='#{@linkUrl}'>link</a></figcaption>"
       end
       source += "</figure>";
       source = safe_wrap(source)


### PR DESCRIPTION
There are many ways to solve this problem, but I found the most elegant to be relocating the link below the code box.  That way both top and bottom can have centered text and can be as long as they need to.  I've set up the following sites to see the difference.

[Pre-Fix](http://williamcombs.com/pre-fix/)
[Post-Fix](http://williamcombs.com/post-fix/)

Let me know what you think.  If you agree, I can move forward and do the same for backtick_code_block and others.

Thanks!
