### PR TITLE
Styles & scripts optimization in the document head

### DIFF
--- a/.themes/classic/source/_includes/head.html
+++ b/.themes/classic/source/_includes/head.html
@@ -20,10 +20,10 @@
   <link rel="canonical" href="{{ canonical }}">
   <link href="{{ root_url }}/favicon.png" rel="icon">
   <link href="{{ root_url }}/stylesheets/screen.css" media="screen, projection" rel="stylesheet" type="text/css">
+  <link href="{{ site.subscribe_rss }}" rel="alternate" title="{{site.title}}" type="application/atom+xml">
+  {% include custom/head.html %}
   <script src="{{ root_url }}/javascripts/modernizr-2.0.js"></script>
   <script src="{{ root_url }}/javascripts/ender.js"></script>
   <script src="{{ root_url }}/javascripts/octopress.js" type="text/javascript"></script>
-  <link href="{{ site.subscribe_rss }}" rel="alternate" title="{{site.title}}" type="application/atom+xml">
-  {% include custom/head.html %}
   {% include google_analytics.html %}
 </head>


### PR DESCRIPTION
CSS must always be included before JS in the document head to allow the CSS files to be downloaded in parallel.

I just moved all the script tags in:

octopress/.themes/classic/source/_includes/head.html

to go after:

{% include custom/head.html %}

so that if custom css and scripts are added in the right order, the overall order will still be CSS before JS.

Hope that all made sense.

-Esteban
