### PR TITLE
Example repo URL - see Github issue 516

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -299,7 +299,9 @@ task :setup_github_pages, :repo do |t, args|
   if args.repo
     repo_url = args.repo
   else
-    repo_url = get_stdin("Enter the read/write url for your repository: ")
+    puts "Enter the read/write url for your repository" 
+    puts "(For example, 'git@github.com:your_username/your_username.github.com)"
+    repo_url = get_stdin("Repository url: ")
   end
   user = repo_url.match(/:([^\/]+)/)[1]
   branch = (repo_url.match(/\/[\w-]+.github.com/).nil?) ? 'gh-pages' : 'master'


### PR DESCRIPTION
Clarifies which repo URL is needed.

When setting up a repo on Github as Octopress suggests, Github gives instructions like: 

```
git remote add origin https://github.com/your_username/your_username.github.com.git
```

But using that URL causes the error discussed on issue 516.
