### PR TITLE
[BUGFIX] Unbreak generate_only task.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -200,10 +200,10 @@ task :isolate, :filename do |t, args|
   else
     filename = get_stdin("Enter a post file name: ")
   end
-  stash_dir = "#{source_dir}/#{stash_dir}"
-  FileUtils.mkdir(stash_dir) unless File.exist?(stash_dir)
+  full_stash_dir = "#{source_dir}/#{stash_dir}"
+  FileUtils.mkdir(full_stash_dir) unless File.exist?(full_stash_dir)
   Dir.glob("#{source_dir}/#{posts_dir}/*.*") do |post|
-    FileUtils.mv post, stash_dir unless post.include?(filename)
+    FileUtils.mv post, full_stash_dir unless post.include?(filename)
   end
 end
 


### PR DESCRIPTION
The isolate task would overwrite the stash_dir local,
breaking the integrate task.
