### PR TITLE
Added trailing slash to archives link

### DIFF
--- a/.themes/classic/source/_includes/custom/navigation.html
+++ b/.themes/classic/source/_includes/custom/navigation.html
@@ -1,4 +1,4 @@
 <ul class="main-navigation">
   <li><a href="{{ root_url }}/">Blog</a></li>
-  <li><a href="{{ root_url }}/blog/archives">Archives</a></li>
+  <li><a href="{{ root_url }}/blog/archives/">Archives</a></li>
 </ul>

--- a/.themes/classic/source/index.html
+++ b/.themes/classic/source/index.html
@@ -14,7 +14,7 @@ layout: default
     {% if paginator.next_page %}
       <a class="prev" href="{{paginator.next_page}}">&larr; Older</a>
     {% endif %}
-    <a href="/blog/archives">Blog Archives</a>
+    <a href="/blog/archives/">Blog Archives</a>
     {% if paginator.previous_page %}
     <a class="next" href="{{paginator.previous_page}}">Newer &rarr;</a>
     {% endif %}


### PR DESCRIPTION
Hello imathis,

I've added a trailing slash to the archives link in the classic theme's source.  I added this for consistency with the trailing slashes in the categories links and because this was breaking my blog when deployed as a static site on Rackspace Cloud Files.

Thanks,
Mike
