### PR TITLE
Fix Twitter integration over SSL

### DIFF
--- a/.themes/classic/source/_includes/sidebars/sections/twitter.html
+++ b/.themes/classic/source/_includes/sidebars/sections/twitter.html
@@ -5,9 +5,9 @@
     <li class="loading">Status updating...</li>
   </ul>
   {% if site.twitter_follow_button %}
-    <a href="http://twitter.com/{{ site.twitter_user }}" class="twitter-follow-button" data-show-count="{{ site.twitter_show_follower_count }}">Follow @{{ site.twitter_user }}</a>
+    <a href="//twitter.com/{{ site.twitter_user }}" class="twitter-follow-button" data-show-count="{{ site.twitter_show_follower_count }}">Follow @{{ site.twitter_user }}</a>
   {% else %}
-    <p>Follow <a href="http://twitter.com/{{site.twitter_user}}">@{{ site.twitter_user }}</a></p>
+    <p>Follow <a href="//twitter.com/{{site.twitter_user}}">@{{ site.twitter_user }}</a></p>
   {% endif %}
 </section>
 {% endif %}

--- a/.themes/classic/source/_includes/twitter_sharing.html
+++ b/.themes/classic/source/_includes/twitter_sharing.html
@@ -4,7 +4,7 @@
       var twitterWidgets = document.createElement('script');
       twitterWidgets.type = 'text/javascript';
       twitterWidgets.async = true;
-      twitterWidgets.src = 'http://platform.twitter.com/widgets.js';
+      twitterWidgets.src = '//platform.twitter.com/widgets.js';
       document.getElementsByTagName('head')[0].appendChild(twitterWidgets);
     })();
   </script>


### PR DESCRIPTION
Twitter is broken when using SSL/TLS. Using protocol relative URL's fixes this.
