### PR TITLE
Fix for issue #622

### DIFF
--- a/plugins/octopress_filters.rb
+++ b/plugins/octopress_filters.rb
@@ -24,12 +24,12 @@ module Jekyll
   class ContentFilters < PostFilter
     include OctopressFilters
     def pre_render(post)
-      if post.ext.match('html|textile|markdown|haml|slim|xml')
+      if post.ext.match('html|textile|markdown|md|haml|slim|xml')
         post.content = pre_filter(post.content)
       end
     end
     def post_render(post)
-      if post.ext.match('html|textile|markdown|haml|slim|xml')
+      if post.ext.match('html|textile|markdown|md|haml|slim|xml')
         post.content = post_filter(post.content)
       end
     end


### PR DESCRIPTION
The filters bundled with Octopress are not applied to files ending in `.md`, because the match in octopress_filters.rb does not match `.md`. The change in commit https://github.com/imathis/octopress/commit/8753a6#plugins/octopress_filters.rb was too strict.
