### PR TITLE
Use GitHub API v3 to fix the GitHub plugin

### DIFF
--- a/.themes/classic/source/javascripts/github.js
+++ b/.themes/classic/source/javascripts/github.js
@@ -10,15 +10,16 @@ var github = (function(){
   return {
     showRepos: function(options){
       $.ajax({
-          url: "http://github.com/api/v2/json/repos/show/"+options.user+"?callback=?"
+          url: "https://api.github.com/users/"+options.user+"/repos?callback=?"
         , type: 'jsonp'
         , error: function (err) { $(options.target + ' li.loading').addClass('error').text("Error loading feed"); }
         , success: function(data) {
           var repos = [];
-          if (!data || !data.repositories) { return; }
-          for (var i = 0; i < data.repositories.length; i++) {
-            if (options.skip_forks && data.repositories[i].fork) { continue; }
-            repos.push(data.repositories[i]);
+          if (!data || !data.data) { return; }
+          for (var i = 0; i < data.data.length; i++) {
+            var currentRepo = data.data[i];
+            if (options.skip_forks && currentRepo.fork) { continue; }
+            repos.push(currentRepo);
           }
           repos.sort(function(a, b) {
             var aDate = new Date(a.pushed_at).valueOf(),


### PR DESCRIPTION
Github API v2 is now deprecated and returning 404 errors, breaking the GitHub plugin.
This commit changes the AJAX call URL to use the v3 API to fix it.
