### PR TITLE
Add humans.txt support into default theme

### DIFF
--- a/.themes/classic/source/_includes/custom/footer.html
+++ b/.themes/classic/source/_includes/custom/footer.html
@@ -1,4 +1,5 @@
 <p>
   Copyright &copy; {{ site.time | date: "%Y" }} - {{ site.author }} -
+  I'm a <a href="{{ root_url }}/humans.txt">human</a> -
   <span class="credit">Powered by <a href="http://octopress.org">Octopress</a></span>
 </p>

--- a/.themes/classic/source/_includes/head.html
+++ b/.themes/classic/source/_includes/head.html
@@ -18,6 +18,7 @@
 
   {% capture canonical %}{{ site.url }}{% if site.permalink contains '.html' %}{{ page.url }}{% else %}{{ page.url | remove:'index.html' }}{% endif %}{% endcapture %}
   <link rel="canonical" href="{{ canonical }}">
+  <link rel="author" href="{{ root_url }}/humans.txt" />
   <link href="{{ root_url }}/favicon.png" rel="icon">
   <link href="{{ root_url }}/stylesheets/screen.css" media="screen, projection" rel="stylesheet" type="text/css">
   <script src="{{ root_url }}/javascripts/modernizr-2.0.js"></script>

--- a/.themes/classic/source/humans.txt
+++ b/.themes/classic/source/humans.txt
@@ -1,0 +1,15 @@
+---
+layout: nil
+---
+ 
+/* TEAM */
+Owner: {{ site.author }}.
+{% if site.email %}Email: {{ site.email }}
+{% endif %}{% if site.twitter_user %}Twitter: @{{ site.twitter_user }}
+{% endif %}{% if site.github_user %}Github: {{ site.github_user }}
+{% endif %}{% if site.location %}Location: {{ site.location }}
+{% endif %}
+
+/* SITE */
+Last update: {{ site.time | date_to_long_string }}
+Software: Octopress, Jekyll

--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,9 @@ subscribe_rss: /atom.xml
 subscribe_email:
 # RSS feeds can list your email address if you like
 email:
+# humans.txt file can list your location if specified
+# it also uses 'author', 'email', 'twitter_user' and  'github_user'
+location:
 
 # ----------------------- #
 #    Jekyll & Plugins     #


### PR DESCRIPTION
This simply adds a `humans.txt` file as specified by the [humanstxt.org](http://humanstxt.org/) initiative. Default content is generated from `_config.yml`.
