### PR TITLE
Fix for small bug in Author generation in Blockquote plugin

### DIFF
--- a/plugins/blockquote.rb
+++ b/plugins/blockquote.rb
@@ -35,11 +35,12 @@ module Jekyll
         @by = $1
         @source = $2 + $3
       elsif markup =~ Author
-        if $1 =~ /([^,]+),([^,]+)/
+        author = $1
+        if author =~ /([^,]+),([^,]+)/
           @by = $1
           @title = $2.titlecase
         else
-          @by = $1
+          @by = author
         end
       end
       super


### PR DESCRIPTION
fixes issue with Blockquote iniitalize method where author is incorrectly set (due to overwriting of match global)
