### PR TITLE
Classic theme: Show Disqus comment count on individual blog entry

### DIFF
--- a/.themes/classic/source/_includes/disqus.html
+++ b/.themes/classic/source/_includes/disqus.html
@@ -1,21 +1,27 @@
 {% comment %} Load script if disquss comments are enabled and `page.comments` is either empty (index) or set to true {% endcomment %}
 {% if site.disqus_short_name and page.comments != false %}
 <script type="text/javascript">
-      var disqus_shortname = '{{ site.disqus_short_name }}';
-      {% if page.comments == true %}
-        {% comment %} `page.comments` can be only be set to true on pages/posts, so we embed the comments here. {% endcomment %}
-        // var disqus_developer = 1;
-        var disqus_identifier = '{{ site.url }}{{ page.url }}';
-        var disqus_url = '{{ site.url }}{{ page.url }}';
-        var disqus_script = 'embed.js';
-      {% else %}
-        {% comment %} As `page.comments` is empty, we must be on the index page. {% endcomment %}
-        var disqus_script = 'count.js';
-      {% endif %}
-    (function () {
-      var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-      dsq.src = 'http://' + disqus_shortname + '.disqus.com/' + disqus_script;
-      (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-    }());
+var insertDisqusScript = function (shortname, script_basename) {
+    var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+    dsq.src = 'http://' + shortname + '.disqus.com/' + script_basename;
+    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+};
+
+var disqus_shortname = '{{ site.disqus_short_name }}';
+{% if page.comments == true %}
+    {% comment %} `page.comments` can be only be set to true on pages/posts, so we embed the comments here. {% endcomment %}
+    // var disqus_developer = 1;
+    var disqus_identifier = '{{ site.url }}{{ page.url }}';
+    var disqus_url = '{{ site.url }}{{ page.url }}';
+    insertDisqusScript(disqus_shortname, "embed.js");
+    {% if site.disqus_show_comment_count == true %}
+        insertDisqusScript(disqus_shortname, "count.js");
+    {% endif %}
+{% else %}
+    {% comment %} As `page.comments` is empty, we must be on the index page. {% endcomment %}
+    {% if site.disqus_show_comment_count == true %}
+        insertDisqusScript(disqus_shortname, "count.js");
+    {% endif %}
+{% endif %}
 </script>
 {% endif %}


### PR DESCRIPTION
I did a little refactoring of the Javascript, and now in the classic theme, when you visit an individual blog entry, you see the Disqus comment/reaction count. Previously you only saw this on the index page.
