### PR TITLE
Add gemset octopress in .rvmrc

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm use 1.9.3
+rvm use --create 1.9.3@octopress


### PR DESCRIPTION
Assign a gemset 'octopress' to .rvmrc rather than using the public gemset
