### PR TITLE
Create a symlink to source file when running new_post

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -109,6 +109,8 @@ task :new_post, :title do |t, args|
     post.puts "categories: "
     post.puts "---"
   end
+  puts "Creating symlink 'latest' pointing to #{filename}"
+  %x[ln -sf #{filename} latest]
 end
 
 # usage rake new_page[my-new-page] or rake new_page[my-new-page.html] or rake new_page (defaults to "new-page.markdown")


### PR DESCRIPTION
I have no idea if anyone else will find this useful, but I _always_ want to edit my new post immediately, and often want to edit it a few times after thinking I'm finished.

This patch simply creates a symlink named 'latest' in the current directory 
which points to the most recent post created via new_post. 
Makes editing new posts easier, by simply doing something like...

``` sh
rake new_post[my new post]
vi latest
```
