### PR TITLE
Sitemap merger rake task for multiple blogs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -370,7 +370,7 @@ task :merge_sitemaps do
     howmany  += 1
   }
   File.open( root_dir + "/sitemap.xml", 'w' ) do |f|
-    f.write ( header + alllines + trailer ).join( "\n" )
+    f.write ( header + alllines + trailer ).join()
   end
   puts "Merged #{howmany} sitemaps onto #{root_dir}/sitemap.xml"
 end


### PR DESCRIPTION
Based on this discussion https://github.com/imathis/octopress/issues/708

Basically some people use different OP instances to manage multiple blogs under the same umbrella. That kind of works, but you get separate sitemap.xml files.

I have added a rake task, merge_sitemaps to merge all the sitemaps inside public/ into public/sitemap.xml file.

I have also edited the generate task to check for a variable is_multiblog before running merge_sitemaps automatically.
