### PR TITLE
setup_github_pages: allow for clones missing .git extension

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -306,7 +306,7 @@ task :setup_github_pages, :repo do |t, args|
   user = repo_url.match(/:([^\/]+)/)[1]
   branch = (repo_url.match(/\/[\w-]+.github.com/).nil?) ? 'gh-pages' : 'master'
   project = (branch == 'gh-pages') ? repo_url.match(/\/([^\.]+)/)[1] : ''
-  unless `git remote -v`.match(/origin.+?octopress.git/).nil?
+  unless `git remote -v`.match(/origin.+?octopress(?:\.git)?/).nil?
     # If octopress is still the origin remote (from cloning) rename it to octopress
     system "git remote rename origin octopress"
     if branch == 'master'


### PR DESCRIPTION
I often clone things from github without the .git extension, and of course, it works.

The rake task :setup_github_pages assumes that origin is going to be a repo called "octopress.git", and if it is not, it will skip a whole bunch of logic, i.e. setting up the remotes and renaming the master branch to source.  The output ends up looking like: 

<pre>
± rake setup_github_pages
Enter the read/write url for your repository
(For example, 'git@github.com:your_username/your_username.github.com)
Repository url: git@github.com:vaz/vaz.github.com

< ... a bunch of suff that should happen here, doesn't ... >

rm -rf _deploy
mkdir _deploy
cd _deploy
Initialized empty Git repository in /Users/vaz/src/ruby/octopress/_deploy/.git/
[master (root-commit) c725303] Octopress init
 1 files changed, 1 insertions(+), 0 deletions(-)
 create mode 100644 index.html
cd -
</pre>


This can be really confusing for a first-time user who probably doesn't have a clear idea what the "source" branch is for yet, yet is expecting to see one based on the documentation (this is what happened to me).

The fix is simply to make the .git ending optional.
