### PR TITLE
"Github" → "GitHub"

### DIFF
--- a/source/_posts/2011-07-22-octopress-20-surfaces.markdown
+++ b/source/_posts/2011-07-22-octopress-20-surfaces.markdown
@@ -7,7 +7,7 @@ comments: true
 categories: release
 ---
 
-Octopress is a framework designed by [Brandon Mathis](http://brandonmathis.com) for [Jekyll](http://github.com/mojombo/jekyll), the blog aware static site generator powering [Github Pages](http://pages.github.com).
+Octopress is a framework designed by [Brandon Mathis](http://brandonmathis.com) for [Jekyll](http://github.com/mojombo/jekyll), the blog aware static site generator powering [GitHub Pages](http://pages.github.com).
 To start blogging with Jekyll, you have to write your own HTML templates, CSS, Javascripts and set up your configuration. But with Octopress
 All of that is already taken care of. Simply [clone or fork Octopress](https://github.com/imathis/octopress), install dependencies and the theme, and you're set.
 
@@ -20,7 +20,7 @@ Octopress comes with:
 - A semantic HTML5 template
 - A Mobile first responsive layout (rotate, or resize your browser and see)
 - Built in 3rd party support for Twitter, Google Plus One, Disqus Comments, Pinboard, Delicious, and Google Analytics
-- An easy deployment strategy using Github pages or Rsync
+- An easy deployment strategy using GitHub Pages or Rsync
 - Built in support for POW and Rack servers
 - Easy theming with Compass and Sass
 - A Beautiful [Solarized](http://ethanschoonover.com/solarized) syntax highlighting
@@ -34,7 +34,7 @@ Most of these plugins have been created just for Octopress, but a few come from 
 - [HTML5 Video Tag](/docs/plugins/video-tag) - *easily post mp4 HTML5 video with flash player fallback*
 - [Code Block](/docs/plugins/codeblock) - *for easy inline code sharing*
 - [Include Code](/docs/plugins/include-code) - *embed code from your filesystem*
-- [Gist Tag](/docs/plugins/gist-tag) - *automatically downloads and embeds Github gists*
+- [Gist Tag](/docs/plugins/gist-tag) - *automatically downloads and embeds GitHub gists*
 - [Image Tag](/docs/plugins/image-tag) - *easily post images with class names and titles*
 - [Render Partial](/docs/plugins/render-partial) - *insert any file into another post or page*
 - [Blockquote](/docs/plugins/blockquote) - *generate beautiful, semantic block quotes*

--- a/source/docs/configuring/index.markdown
+++ b/source/docs/configuring/index.markdown
@@ -75,7 +75,7 @@ If you want to publish your site to a subdirectory, [(see Deploying Octopress to
 <h3 id="third_party">3rd Party Settings</h3>
 These third party integrations are already set up for you. Simply fill in the configurations and they'll be added to your site.
 
-- **Github** - *List your github repositories in the sidebar*
+- **GitHub** - *List your GitHub repositories in the sidebar*
 - **Twitter** - *Setup a sidebar twitter feed, follow button, and tweet button (for sharing posts and pages).*
 - **Google Plus One** - *Setup sharing for posts and pages on Google's plus one network.*
 - **Pinboard** - *Share your recent Pinboard bookmarks in the sidebar.*

--- a/source/docs/deploying/github/index.markdown
+++ b/source/docs/deploying/github/index.markdown
@@ -1,18 +1,18 @@
 ---
 layout: page
-title: "Deploying to Github Pages"
+title: "Deploying to GitHub Pages"
 date: 2011-09-10 17:52
 sidebar: false
 footer: false
 ---
 
-## With Github User/Organization pages
+## With GitHub User/Organization pages
 
 Use this if you want to host a blog from `http://username.github.com` (though you can also use [custom domains](#custom_domains)).
 
-Create a [new Github repository](https://github.com/repositories/new) and name the repository with your user name or organization name `username.github.com` or `organization.github.com`.
+Create a [new GitHub repository](https://github.com/repositories/new) and name the repository with your user name or organization name `username.github.com` or `organization.github.com`.
 
-Github Pages for users and organizations uses the master branch like the public directory on a web server, serving up the files at your Pages url `http://username.github.com`.
+GitHub Pages for users and organizations uses the master branch like the public directory on a web server, serving up the files at your Pages url `http://username.github.com`.
 As a result, you'll want to work on the source for your blog in the source branch and commit *the generated content* to the master branch. Octopress has a configuration task that helps you set all this up.
 
 ``` sh
@@ -21,9 +21,9 @@ rake setup_github_pages
 
 This will:
 
-1. Ask you for your Github Pages repository url.
+1. Ask you for your GitHub Pages repository url.
 2. Rename the remote pointing to imathis/octopress from 'origin' to 'octopress'
-3. Add your Github Pages repository as the default origin remote.
+3. Add your GitHub Pages repository as the default origin remote.
 4. Switch the active branch from master to source.
 5. Configure your blog's url according to your repository.
 6. Setup a master branch in the _deploy directory for deployment.
@@ -36,7 +36,7 @@ rake deploy
 ```
 
 This will generate your blog, copy the generated files into `_deploy/`, add them to git, commit and push them up to the master branch. In a few seconds you should get an email
-from Github telling you that your commit has been received and will be published on your site.
+from GitHub telling you that your commit has been received and will be published on your site.
 
 **Don't forget** to commit the source for your blog.
 
@@ -46,13 +46,13 @@ git commit -m 'your message'
 git push origin source
 ```
 
-**Note:** With new repositories, Github sets the default branch based on the branch you push first, and it looks there for the generated site content.
-If you're having trouble getting Github to publish your site, go to the admin panel for your repository and make sure that the master branch is the default branch.
+**Note:** With new repositories, GitHub sets the default branch based on the branch you push first, and it looks there for the generated site content.
+If you're having trouble getting GitHub to publish your site, go to the admin panel for your repository and make sure that the master branch is the default branch.
 
-## With Github Project pages (gh-pages)
+## With GitHub Project pages (gh-pages)
 
-Github's Project Pages service allows you to host a site for your existing open source project.
-Github will look for a `gh-pages` branch in your project's repository and make the contents available at url like `http://username.github.com/project`.
+GitHub's Project Pages service allows you to host a site for your existing open source project.
+GitHub will look for a `gh-pages` branch in your project's repository and make the contents available at url like `http://username.github.com/project`.
 
 Here's now you can set up Octopress site to publish to your projects gh-pages repository:
 
@@ -75,7 +75,7 @@ rake deploy
 ```
 
 This will generate your blog, copy the generated files into `_deploy/`, add them to git, commit and push them up to the master branch. In a few seconds you should get an email
-from Github telling you that your commit has been received and will be published on your site.
+from GitHub telling you that your commit has been received and will be published on your site.
 
 Now you have a place to commit the generated content for your site, but you should also set up repository to store the source for your blog.
 After you set up a repository for your blog source, add it as the origin remote.
@@ -96,7 +96,7 @@ First you'll need to create a file named `CNAME` in the source containing your d
 echo 'your-domain.com' >> source/CNAME
 ```
 
-From [Github's Pages guide](http://help.github.com/pages/#custom_domains):<br>
+From [GitHub's Pages guide](http://help.github.com/pages/#custom_domains):<br>
 Next, you’ll need to visit your domain registrar or DNS host and add a record for your domain name.
 For a sub-domain like `www.example.com` you would simply create a CNAME record pointing at `charlie.github.com`.
 If you are using a top-level domain like `example.com`, you must use an A record pointing to `207.97.227.245`.

--- a/source/docs/deploying/heroku/index.markdown
+++ b/source/docs/deploying/heroku/index.markdown
@@ -17,7 +17,7 @@ gem install heroku
 ```
 
 Next create a heroku app for deployment. If this is your first time using Heroku, this command will ask for your account credentials,
-and automatically upload your public SSH key. If you don't already have a public key follow [Github's guide and create one](http://help.github.com/set-up-git-redirect/).
+and automatically upload your public SSH key. If you don't already have a public key follow [GithHub's guide and create one](http://help.github.com/set-up-git-redirect/).
 
 ```sh
 heroku create

--- a/source/docs/deploying/index.markdown
+++ b/source/docs/deploying/index.markdown
@@ -8,14 +8,14 @@ footer: false
 
 Here are some nice and easy ways to deploy your Octopress blog.
 
-## Github Pages
-Hosting your blog with Github's [Pages service](http://pages.github.com) is free and allows custom domains. To deploy you simply push your repository to Gihub.
+## GitHub Pages
+Hosting your blog with GitHub's [Pages service](http://pages.github.com) is free and allows custom domains. To deploy you simply push your repository to GitHub.
 This is a great way to host a personal blog, or even a multi-author blog, where contributions can be handled with pull requests and commit access.
 
-[Deploying to Github Pages &raquo;](/docs/deploying/github)
+[Deploying to GitHub Pages &raquo;](/docs/deploying/github)
 
 ## Heroku
-Like Github Pages, Heroku is also free, allows custom domains, and uses a git based deployment workflow. Heroku is a bit simpler to use and your blog repository remains private.
+Like GitHub Pages, Heroku is also free, allows custom domains, and uses a git based deployment workflow. Heroku is a bit simpler to use and your blog repository remains private.
 
 [Deploying to Heroku &raquo;](/docs/deploying/heroku)
 

--- a/source/docs/deploying/rsync/index.markdown
+++ b/source/docs/deploying/rsync/index.markdown
@@ -52,7 +52,7 @@ Note: using excludes will prevent rsync from uploading local files, or if the de
 ## Version control
 
 You'll want to keep your blog source in a remote git repository,
-so either [set up a Github repository](https://github.com/repositories/new) or [host your own](#self_hosted_git) and then do this.
+so either [set up a GitHub repository](https://github.com/repositories/new) or [host your own](#self_hosted_git) and then do this.
 
 ```sh
 # Since you cloned Octopress, you'll need to change the origin remote

--- a/source/docs/deploying/subdir/index.markdown
+++ b/source/docs/deploying/subdir/index.markdown
@@ -6,7 +6,7 @@ sidebar: false
 footer: false
 ---
 
-If you're deploying to a subdirectory on your site, or if you're using Github's project pages, make sure you set up your urls correctly in your configs.
+If you're deploying to a subdirectory on your site, or if you're using GitHub's project pages, make sure you set up your urls correctly in your configs.
 You can do this *almost* automatically:
 
 ``` sh

--- a/source/docs/index.markdown
+++ b/source/docs/index.markdown
@@ -7,7 +7,7 @@ comments: false
 footer: false
 ---
 
-Octopress is a framework designed for Jekyll, the static blogging engine powering Github Pages. Have a look through
+Octopress is a framework designed for Jekyll, the static blogging engine powering GitHub Pages. Have a look through
 the documentation and if you have trouble, [I'll be happy to help](/help). If you find errors in the documentation
 [post an issue](https://github.com/imathis/octopress/issues) or fork and send a pull request on the [site branch](https://github.com/imathis/octopress/tree/site).
 
@@ -22,7 +22,7 @@ This section will help you get set up, and explain how to configure Octopress fo
 Your blog should be awesome. This should help.
 
 - [Blogging Basics](/docs/blogging) - *how to create blog posts and pages*
-- [Deploying Octopress](/docs/deploying) - *simple deploy instructions for Rsync and Github pages*
+- [Deploying Octopress](/docs/deploying) - *simple deploy instructions for Rsync and GitHub Pages*
 - [Sharing Code Snippets](/docs/blogging/code) - *share code snippets with ease*
 - [Blogging With Plugins](/docs/blogging/plugins) - *overview of plugins for blogging*
 - [Theming & Customization](/docs/theme) - *guide to making changes to your Octopress theme*

--- a/source/docs/plugins/backtick-codeblock/index.markdown
+++ b/source/docs/plugins/backtick-codeblock/index.markdown
@@ -6,7 +6,7 @@ sidebar: false
 footer: false
 ---
 
-With the `backtick_codeblock` filter you can use Github's lovely back tick syntax highlighting blocks.
+With the `backtick_codeblock` filter you can use GitHub's lovely back tick syntax highlighting blocks.
 Simply start a line with three back ticks followed by a space and the language you're using.
 
 ## Syntax

--- a/source/docs/plugins/gist-tag/index.markdown
+++ b/source/docs/plugins/gist-tag/index.markdown
@@ -7,7 +7,7 @@ footer: false
 ---
 
 All you need is the gist's id and you can easily embed it in your page. This actually downloads a cache of the gist and embeds it in a `<noscript>` tag for RSS
-readers and search engines, while still using Github's javascript gist embed code for browsers.
+readers and search engines, while still using GitHub's JavaScript gist embed code for browsers.
 
 #### Syntax
 

--- a/source/docs/plugins/index.markdown
+++ b/source/docs/plugins/index.markdown
@@ -13,7 +13,7 @@ Octopress ships with the following plugins. Many have been written specially for
 - [Backtick Code Block](/docs/plugins/backtick-codeblock/) - *for simple lightweight code sharing*
 - [Code Block](/docs/plugins/codeblock/) - *for sharing code with titles and links*
 - [Include Code](/docs/plugins/include-code/) - *embed code from your filesystem with a download link*
-- [Gist Tag](/docs/plugins/gist-tag/) - *automatically downloads and embeds Github gists*
+- [Gist Tag](/docs/plugins/gist-tag/) - *automatically downloads and embeds GitHub gists*
 - [jsFiddle](/docs/plugins/jsfiddle-tag/) - *embeds code from jsFiddle*
 - [Image Tag](/docs/plugins/image-tag/) - *easily post images with class names and titles*
 - [Render Partial](/docs/plugins/render-partial/) - *insert any file into another post or page*

--- a/source/docs/theme/styles/_colors.markdown
+++ b/source/docs/theme/styles/_colors.markdown
@@ -13,7 +13,7 @@ To customize your color scheme edit `sass/custom/_colors.scss` and override the 
 
 The official Octopress site is using the default 'classic' theme with a few minor color changes to the custom colors file. Take a look at this file and you'll see some lines of sass code that have been commented out.
 
-{% codeblock Custom Colors (sass/custom/_colors.scss) https://github.com/imathis/octopress/tree/master/.themes/classic/sass/custom/_colors.scss View on Github %}
+{% codeblock Custom Colors (sass/custom/_colors.scss) https://github.com/imathis/octopress/tree/master/.themes/classic/sass/custom/_colors.scss View on GitHub %}
 $header-bg: #263347;
 $subtitle-color: lighten($header-bg, 58);
 $nav-bg: desaturate(lighten(#8fc17a, 18), 5);
@@ -24,7 +24,7 @@ $sidebar-link-color-hover: darken(#7ab662, 9);
 
 The custom colors file has some commented out colors you can use. The theme file is broken up into sections to make it easier to read through. Here's a look at the navigation section of `sass/base/_theme.scss`.
 
-{% codeblock Navigation (sass/base/_theme.scss) https://github.com/imathis/octopress/tree/master/.themes/classic/sass/base/_theme.scss View on Github %}
+{% codeblock Navigation (sass/base/_theme.scss) https://github.com/imathis/octopress/tree/master/.themes/classic/sass/base/_theme.scss View on GitHub %}
 /* Navigation */
 $nav-bg: #ccc !default;
 $nav-color: darken($nav-bg, 38) !default;

--- a/source/docs/theme/styles/_layout.markdown
+++ b/source/docs/theme/styles/_layout.markdown
@@ -7,7 +7,7 @@
 Just like with colors, widths in `/sass/base/_layout.scss` are defined like `$max-width: 1200px !default;` and can be easily customized
 by defining them in `sass/custom/_layout.scss`. Here's a look at the layout defaults.
 
-{% codeblock Layout Defaults (_layout.scss) https://github.com/imathis/octopress/tree/master/.themes/classic/sass/base/_layout.scss view on Github %}
+{% codeblock Layout Defaults (_layout.scss) https://github.com/imathis/octopress/tree/master/.themes/classic/sass/base/_layout.scss view on GitHub %}
 $max-width: 1200px !default;
 
 // Padding used for layout margins

--- a/source/help/index.markdown
+++ b/source/help/index.markdown
@@ -18,11 +18,11 @@ Don't feel like reading the documentation? You've come to the right place! Actua
 If you have a question, or if you love helping others:
 
 1. Join the #Octopress IRC channel on irc.freenode.net.
-2. [Post an issue](http://github.com/imathis/octopress/issues) on Github's issue tracker.
+2. [Post an issue](http://github.com/imathis/octopress/issues) on GitHub's issue tracker.
 3. Mention [@Octopress](http://twitter.com/octopress) on Twitter.
 
 ## Contributing
 
-If you want to help out, [fork Octopress on Github](http://github.com/imathis/octopress) and send me a pull request.
+If you want to help out, [fork Octopress on GitHub](http://github.com/imathis/octopress) and send me a pull request.
 This site is also part of the Octopress project and if you find errors you can [post issues](http://github.com/imathis/octopress/issues/)
 or send me a pull request for the [site branch](http://github.com/imathis/octopress/tree/site).


### PR DESCRIPTION
Camel casing all instances of "Github" → "GitHub" on the website.
