### PR TITLE
Make jsFiddle tag plugin accept link with update

### DIFF
--- a/plugins/jsfiddle.rb
+++ b/plugins/jsfiddle.rb
@@ -18,7 +18,7 @@
 module Jekyll
   class JsFiddle < Liquid::Tag
     def initialize(tag_name, markup, tokens)
-      if /(?<fiddle>\w+)(?:\s+(?<sequence>[\w,]+))?(?:\s+(?<skin>\w+))?(?:\s+(?<height>\w+))?(?:\s+(?<width>\w+))?/ =~ markup
+      if /(?<fiddle>\w+(\/\d+)?)(?:\s+(?<sequence>[\w,]+))?(?:\s+(?<skin>\w+))?(?:\s+(?<height>\w+))?(?:\s+(?<width>\w+))?/ =~ markup
         @fiddle   = fiddle
         @sequence = (sequence unless sequence == 'default') || 'js,resources,html,css,result'
         @skin     = (skin unless skin == 'default') || 'light'


### PR DESCRIPTION
Hi, I change the regex of jsFiddle tag plugin, make it accept the updated link like "uf4ey/1". Hope this help and thanks your awesome framework.
