### PR TITLE
Don't show Permalink in feed for non-linkblog entries

### DIFF
--- a/.themes/classic/source/_includes/feed_entry.xml
+++ b/.themes/classic/source/_includes/feed_entry.xml
@@ -2,7 +2,7 @@
 {% if post.external-url %}{% capture linklog %}{{ post.external-url }}{% endcapture %}{% endif %}
 {% capture title_url %}{% if linklog %}{{ linklog }}{% else %}{{ site.url }}{{ post.url }}{% endif %}{% endcapture %}
 {% capture title %}{% if linklog and site.linklog_marker_position_feed == 'before' %}{% unless linklog %}{{ site.standard_post_marker }}{% endunless %}{{ site.linklog_marker }} {% endif %}{{ post.title }}{% if linklog and site.linklog_marker_position_feed == 'after' %} {{ site.linklog_marker }}{% endif %}{% endcapture %}
-{% capture content %}{% if site.excerpt_in_feed %}{{ post.content | excerpt | expand_urls: site.url }}<p><a rel="bookmark" href="{{ site.url }}{{ post.url }}">{{ site.excerpt_link }}</a></p>{% else %}{{ post.content | expand_urls: site.url }}<p><a rel="bookmark" href="{{ site.url }}{{ post.url }}">{{ site.permalink_label_feed }}</a></p>{% endif %}{% endcapture %}
+{% capture content %}{% if site.excerpt_in_feed %}{{ post.content | excerpt | expand_urls: site.url }}<p><a rel="bookmark" href="{{ site.url }}{{ post.url }}">{{ site.excerpt_link }}</a></p>{% else %}{{ post.content | expand_urls: site.url }}{% endif %}{% if linklog and site.permalink_label_feed %}<p><a rel="bookmark" href="{{ site.url }}{{ post.url }}">{{ site.permalink_label_feed }}</a></p>{% endif %}{% endcapture %}
 <title type="html"><![CDATA[{{ title | cdata_escape }}]]></title>
 <link href="{{ title_url }}"/>
 <updated>{{ post.date | date_to_xmlschema }}</updated>


### PR DESCRIPTION
The permalink at the bottom of a feed entry only makes sense for
linkblog posts. For non-linkblog posts, it should not be displayed in
the feed entry since the title already links to the post.
