### PR TITLE
Hide sidebar for index page

### DIFF
--- a/.themes/classic/source/index.html
+++ b/.themes/classic/source/index.html
@@ -20,6 +20,7 @@ layout: default
     {% endif %}
   </div>
 </div>
+{% unless page.sidebar == false %}
 <aside class="sidebar">
   {% if site.blog_index_asides.size %}
     {% include_array blog_index_asides %}
@@ -27,3 +28,4 @@ layout: default
     {% include_array default_asides %}
   {% endif %}
 </aside>
+{% endunless %}


### PR DESCRIPTION
If you hide sidebar for index page layout will be built incorrectly.
![Bug preview](https://www.evernote.com/shard/s162/sh/55c915cb-4b45-4a87-8c99-05faa551fe98/2ae7dc1d32387749da6b5d0ba6660a8d/res/d27313b3-728f-4abe-8ff2-c2f64e273346/skitch.png)
