### PR TITLE
Change full_url to work with pages too.

### DIFF
--- a/plugins/post_filters.rb
+++ b/plugins/post_filters.rb
@@ -167,10 +167,14 @@ module Jekyll
       old_do_layout(payload, layouts)
     end
 
-    # Returns the full url of the post, including the
-    # configured url
+    ##
+    # Returns the full url of the post or page, including the configured URL.
+    ##
+
     def full_url
-      self.site.config['url'] + self.url
+      if is_post?
+        site.config["url"] + url
+      else (site.config['url'] + @dir + url).gsub(%r!index.html$!, "") end
     end
   end
 end


### PR DESCRIPTION
This proposed patch adjusts full_url to also be useful for pages so it should return a URL no matter what type of content it is (that is if the content is a post or page.)  Since "post_filters.rb" already contains agnostic code for the most part, I would hope this would not harm the core of Octopress.
