### PR TITLE
Add some basic styling for HTML tables

### DIFF
--- a/.themes/classic/sass/_base.scss
+++ b/.themes/classic/sass/_base.scss
@@ -3,3 +3,4 @@
 @import "base/theme";
 @import "base/typography";
 @import "base/layout";
+@import "base/table";

--- a/.themes/classic/sass/base/_table.scss
+++ b/.themes/classic/sass/base/_table.scss
@@ -1,0 +1,31 @@
+* + table {
+  border-style:solid;
+  border-width:1px;
+  border-color:#e7e3e7;
+}
+
+* + table th, * + table td {
+  border-style:dashed;
+  border-width:1px;
+  border-color:#e7e3e7;
+  padding-left: 3px;
+  padding-right: 3px;
+}
+
+* + table th {
+  border-style:solid;
+  font-weight:bold;
+  background: url("/images/noise.png?1330434582") repeat scroll left top #F7F3F7;
+}
+
+* + table th[align="left"], * + table td[align="left"] {
+  text-align:left;
+}
+
+* + table th[align="right"], * + table td[align="right"] {
+  text-align:right;
+}
+
+* + table th[align="center"], * + table td[align="center"] {
+  text-align:center;
+}


### PR DESCRIPTION
Inspired by [this](http://samwize.com/2012/09/24/octopress-table-stylesheet/) blog post, here's some basic CSS styling for HTML tables added to the classic theme.
