### PR TITLE
decode path

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,6 @@
 require 'bundler/setup'
 require 'sinatra/base'
+require 'uri'
 
 # The project root directory
 $root = ::File.dirname(__FILE__)
@@ -15,6 +16,7 @@ class SinatraStaticServer < Sinatra::Base
   end
 
   def send_sinatra_file(path, &missing_file_block)
+    path = URI.decode(path)
     file_path = File.join(File.dirname(__FILE__), 'public',  path)
     file_path = File.join(file_path, 'index.html') unless file_path =~ /\.[a-z]+$/i  
     File.exist?(file_path) ? send_file(file_path) : missing_file_block.call


### PR DESCRIPTION
because path was encode but not decode yet.
this patch used to apply to any category which contains non-english words, for example, chinese
