### PR TITLE
Do/Don't publish future-dated posts using jekyll's built-in support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -47,20 +47,32 @@ end
 # Working with Jekyll #
 #######################
 
+publish_future_dated_posts_switch = "" # backwards-compatible default value
+
+desc "Read Jekyll configuration"
+task :read_jekyll_configuration do
+  jekyll_configuration = YAML.load_file("./_config.yml")
+
+  # As of this writing, jekyll's default option is --future
+  publish_future_dated_posts_option = jekyll_configuration.has_key?("publish_future_dated_posts") ? jekyll_configuration["publish_future_dated_posts"] : true
+  publish_future_dated_posts_switch = publish_future_dated_posts_option ? "--future" : "--no-future"
+end
+
 desc "Generate jekyll site"
 task :generate do
   raise "### You haven't set anything up yet. First run `rake install` to set up an Octopress theme." unless File.directory?(source_dir)
   puts "## Generating Site with Jekyll"
   system "compass compile --css-dir #{source_dir}/stylesheets"
-  system "jekyll"
+  system "jekyll #{publish_future_dated_posts_switch}"
 end
+task :generate => :read_jekyll_configuration
 
 desc "Watch the site and regenerate when it changes"
 task :watch do
   raise "### You haven't set anything up yet. First run `rake install` to set up an Octopress theme." unless File.directory?(source_dir)
   puts "Starting to watch source with Jekyll and Compass."
   system "compass compile --css-dir #{source_dir}/stylesheets" unless File.exist?("#{source_dir}/stylesheets/screen.css")
-  jekyllPid = Process.spawn({"OCTOPRESS_ENV"=>"preview"}, "jekyll --auto")
+  jekyllPid = Process.spawn({"OCTOPRESS_ENV"=>"preview"}, "jekyll --auto #{publish_future_dated_posts_switch}")
   compassPid = Process.spawn("compass watch")
 
   trap("INT") {
@@ -70,6 +82,7 @@ task :watch do
 
   [jekyllPid, compassPid].each { |pid| Process.wait(pid) }
 end
+task :watch => :read_jekyll_configuration
 
 desc "preview the site in a web browser"
 task :preview do

--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,7 @@ recent_posts: 5       # Posts in the sidebar Recent Posts section
 excerpt_link: "Read on &rarr;"  # "Continue reading" link text at the bottom of excerpted articles
 
 titlecase: true       # Converts page and post titles to titlecase
+publish_future_dated_posts: false
 
 # list each of the sidebar modules you want to include, in the order you want them to appear.
 # To add custom asides, create files in /source/_includes/custom/asides/ and add them to the list like 'custom/asides/custom_aside_name.html'


### PR DESCRIPTION
I've added a configuration variable, and discovered that `jekyll` already supported this with a switch, which made it much easier.
