### PR TITLE
Add option for size-only rsync deploys

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,7 @@ ssh_user       = "user@domain.com"
 ssh_port       = "22"
 document_root  = "~/website.com/"
 rsync_delete   = false
+rsync_size_only = false
 deploy_default = "rsync"
 
 # This will be configured for you when you run config_deploy
@@ -237,7 +238,7 @@ task :rsync do
     exclude = "--exclude-from '#{File.expand_path('./rsync-exclude')}'"
   end
   puts "## Deploying website via Rsync"
-  ok_failed system("rsync -avze 'ssh -p #{ssh_port}' #{exclude} #{"--delete" unless rsync_delete == false} #{public_dir}/ #{ssh_user}:#{document_root}")
+  ok_failed system("rsync #{"--size-only" unless rsync_size_only == false} -avze 'ssh -p #{ssh_port}' #{exclude} #{"--delete" unless rsync_delete == false} #{public_dir}/ #{ssh_user}:#{document_root}")
 end
 
 desc "deploy public directory to github pages"


### PR DESCRIPTION
Since `jekyll` regenerates time-stamps for all the files and by default `rsync` checks size and modified dates for files, all the files are usually deployed via `rsync`.

I added an option in the `Rakefile` so that `rsync` can be set with the option `--size-only` so that modified dates will not be taken into account when deciding if a file should be deployed. This means that only changed files will be uploaded.

I made it default to `false` so behavior will be the same if defaults are not changed.
