### PR TITLE
Rakefile option for any additional rsync arguments

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,7 @@ ssh_user       = "user@domain.com"
 ssh_port       = "22"
 document_root  = "~/website.com/"
 rsync_delete   = false
+rsync_args     = ""  # Any extra arguments to pass to rsync
 deploy_default = "rsync"
 
 # This will be configured for you when you run config_deploy
@@ -237,7 +238,7 @@ task :rsync do
     exclude = "--exclude-from '#{File.expand_path('./rsync-exclude')}'"
   end
   puts "## Deploying website via Rsync"
-  ok_failed system("rsync -avze 'ssh -p #{ssh_port}' #{exclude} #{"--delete" unless rsync_delete == false} #{public_dir}/ #{ssh_user}:#{document_root}")
+  ok_failed system("rsync -avze 'ssh -p #{ssh_port}' #{exclude} #{rsync_args} #{"--delete" unless rsync_delete == false} #{public_dir}/ #{ssh_user}:#{document_root}")
 end
 
 desc "deploy public directory to github pages"


### PR DESCRIPTION
Added config variable `rsync_args` to `Rakefile`, to use for any extra arguments you might want to pass to rsync.

For my webhost I need to set file permissions for when rsync uploads stuff by passing `--chmod=Fa+r` to it. Figured I'd share that simple little change. It gets really messy really quick editing the `system()` call in the :`rsync` task.
