### PR TITLE
Fix broken gist plugin

### DIFF
--- a/plugins/gist_tag.rb
+++ b/plugins/gist_tag.rb
@@ -40,7 +40,9 @@ module Jekyll
     end
 
     def script_url_for(gist_id, filename)
-      "https://gist.github.com/#{gist_id}.js?file=#{filename}"
+      url = "https://gist.github.com/#{gist_id}.js"
+      url += "?file=#{filename}" if filename && filename != ''
+      url
     end
 
     def get_gist_url_for(gist, file)


### PR DESCRIPTION
The new gist API doesn't understand a blank file parameter. This fix builds a script URL without a file name when the filename is not present.
