### PR TITLE
Strictly compile in :generate

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -52,7 +52,7 @@ task :generate do
   raise "### You haven't set anything up yet. First run `rake install` to set up an Octopress theme." unless File.directory?(source_dir)
   puts "## Generating Site with Jekyll"
   system "compass compile --css-dir #{source_dir}/stylesheets"
-  system "jekyll"
+  system "jekyll --no-server --no-auto"
 end
 
 desc "Watch the site and regenerate when it changes"


### PR DESCRIPTION
If a user changes his or her `_config.yml` to start a server or auto-generate, `rake generate` should override this and strictly compile the files.
