### PR TITLE
Rack should unescape submitted URLs

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -7,7 +7,7 @@ $root = ::File.dirname(__FILE__)
 class SinatraStaticServer < Sinatra::Base  
 
   get(/.+/) do
-    send_sinatra_file(request.path) {404}
+    send_sinatra_file(unescape request.path) {404}
   end
 
   not_found do


### PR DESCRIPTION
@nicinabox [pointed out a bug in PR 803](https://github.com/imathis/octopress/pull/803#issuecomment-10136898) that has to do with non-ascii URL requests. This is his fix. Works like a charm for me.
