### PR TITLE
Google Group for Support Help

### DIFF
--- a/source/help/index.markdown
+++ b/source/help/index.markdown
@@ -26,3 +26,5 @@ If you have a question, or if you love helping others:
 If you want to help out, [fork Octopress on Github](http://github.com/imathis/octopress) and send me a pull request.
 This site is also part of the Octopress project and if you find errors you can [post issues](http://github.com/imathis/octopress/issues/)
 or send me a pull request for the [site branch](http://github.com/imathis/octopress/tree/site).
+
+Please file all development issues on [Octopress's main repository](https://github.com/imathis/octopress/issues).


### PR DESCRIPTION
Help page in the docs should point peeps to Google Groups for help with issues that aren't dev issues.
