### PR TITLE
Adds 'cs' filetype to pygments

### DIFF
--- a/plugins/pygments_code.rb
+++ b/plugins/pygments_code.rb
@@ -35,6 +35,7 @@ module HighlightCode
     lang = 'perl' if lang == 'pl'
     lang = 'yaml' if lang == 'yml'
     lang = 'coffeescript' if lang == 'coffee'
+    lang = 'csharp' if lang == 'cs'
     lang = 'plain' if lang == '' or lang.nil? or !lang
 
     caption = options[:caption]   || nil


### PR DESCRIPTION
This adds 'cs' so it doesn't throw an exception. I have a couple of other questions though.
1. How should we handle unknown filetypes. Throwing an exception doesn't seem like the best options. Perhaps printing a warning and falling back to 'plain' would be best (unless pygments supports another way to detect)
2. Is there a way to add all of pygments filetypes easily? They have listing (http://pygments.org/docs/lexers/) which includes the file extensions, so I'm surprised it doesn't just detect based on extensions somehow.

If no one knows the answers to these questions I'll do some digging and see if I can't find a way.
