### PR TITLE
docs: supported languages link (pygments)

### DIFF
--- a/source/docs/plugins/backtick-codeblock/index.markdown
+++ b/source/docs/plugins/backtick-codeblock/index.markdown
@@ -16,7 +16,7 @@ Simply start a line with three back ticks followed by a space and the language y
     ```
 ### Basic options
 
-- `[language]` - Used by the syntax highlighter. Passing 'plain' disables highlighting.
+- `[language]` - Used by the syntax highlighter. Passing 'plain' disables highlighting. ([Supported languages](http://pygments.org/docs/lexers/).)
 - `[title]` - Add a figcaption to your code block.
 - `[url]` - Download or reference link for your code.
 - `[Link text]` - Text for the link, defaults to 'link'.

--- a/source/docs/plugins/codeblock/index.markdown
+++ b/source/docs/plugins/codeblock/index.markdown
@@ -16,7 +16,7 @@ With this plugin you can write blocks of code directly in your posts and optiona
 
 ### Basic options
 
-- `[lang:language]` - Choose a language for the syntax highlighter. Passing 'plain' disables highlighting.
+- `[lang:language]` - Choose a language for the syntax highlighter. Passing 'plain' disables highlighting. ([Supported languages](http://pygments.org/docs/lexers/).)
 - `[title]` - Add a figcaption to your code block.
 - `[url]` - Download or reference link for your code.
 - `[link text]` - Text for the link, defaults to 'link'.

--- a/source/docs/plugins/gist-tag/index.markdown
+++ b/source/docs/plugins/gist-tag/index.markdown
@@ -19,7 +19,7 @@ readers and search engines, while still using Github's javascript gist embed cod
 
 {% gist 4321346 %}
 
-If you want syntax highlighting, specify the filename (with extension):
+If you want syntax highlighting (for a [supported language](http://pygments.org/docs/lexers/)), specify the filename (with extension):
 
     {{ "{% gist 4321346 gistfile1.diff" }} %}
 


### PR DESCRIPTION
Added link on 3 doc pages to the appropriate pygments page describing supported languages.
