### PR TITLE
added ssh keys support (e.g. for Amazon ec2)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,7 @@ require 'rake/minify'
 # Be sure your public key is listed in your server's ~/.ssh/authorized_keys file
 ssh_user       = "user@domain.com"
 ssh_port       = "22"
+ssh_key        = ""
 document_root  = "~/website.com/"
 rsync_delete   = false
 rsync_args     = ""  # Any extra arguments to pass to rsync
@@ -289,7 +290,7 @@ task :rsync do
     exclude = "--exclude-from '#{File.expand_path('./rsync-exclude')}'"
   end
   puts "## Deploying website via Rsync"
-  ok_failed system("rsync -avze 'ssh -p #{ssh_port}' #{exclude} #{rsync_args} #{"--delete" unless rsync_delete == false} #{public_dir}/ #{ssh_user}:#{document_root}")
+  ok_failed system("rsync -avze 'ssh -p #{ssh_port} #{'-i' + ssh_key unless ssh_key.empty?}' #{exclude} #{rsync_args} #{"--delete" unless rsync_delete == false} #{public_dir}/ #{ssh_user}:#{document_root}")
 end
 
 desc "deploy public directory to github pages"


### PR DESCRIPTION
Added SSH keys support for RSYNC deploy.
Some hosts need SSH keys (like Amazon ec2) and with this patch it's just needed to fill in the `ssh_key` with the right path, e.g. 

``` ruby
ssh_key = '/Users/x/.ssh/amazon.pem'
```
