### PR TITLE
Fix crash with nil passes

### DIFF
--- a/plugins/octopress_filters.rb
+++ b/plugins/octopress_filters.rb
@@ -126,7 +126,7 @@ module OctopressLiquidFilters
 
   # Returns a title cased string based on John Gruber's title case http://daringfireball.net/2008/08/title_case_update
   def titlecase(input)
-    input.titlecase
+    input.titlecase unless input.nil?
   end
 
 end


### PR DESCRIPTION
Fix cases where a nil variable is passed to the titlecase method instead of a string.
