### PR TITLE
Escape github repo descriptions, as they may contain HTML.

### DIFF
--- a/.themes/classic/source/javascripts/github.js
+++ b/.themes/classic/source/javascripts/github.js
@@ -1,9 +1,12 @@
 var github = (function(){
+  function escapeHtml(str) {
+    return $('<div/>').text(str).html();
+  }
   function render(target, repos){
     var i = 0, fragment = '', t = $(target)[0];
 
     for(i = 0; i < repos.length; i++) {
-      fragment += '<li><a href="'+repos[i].html_url+'">'+repos[i].name+'</a><p>'+(repos[i].description||'')+'</p></li>';
+      fragment += '<li><a href="'+repos[i].html_url+'">'+repos[i].name+'</a><p>'+escapeHtml(repos[i].description||'')+'</p></li>';
     }
     t.innerHTML = fragment;
   }


### PR DESCRIPTION
Fixes this issue:

![github repo description with html](http://i.imgur.com/Hy2B2.png)
