### PR TITLE
Fix nil path when not using gist cache

### DIFF
--- a/plugins/pygments_code.rb
+++ b/plugins/pygments_code.rb
@@ -62,7 +62,7 @@ module HighlightCode
   end
 
   def read_cache (path)
-    code = File.exist?(path) ? File.read(path) : nil
+    code = File.exist?(path) ? File.read(path) : nil unless path.nil?
   end
 
   def get_cache_path (dir, name, str)


### PR DESCRIPTION
Catches a nil path when not using the `.gist-cache` setup.
