### PR TITLE
Hide Google Plus link if google_plus_hidden is true

### DIFF
--- a/.themes/classic/source/_includes/sidebars/sections/google_plus.html
+++ b/.themes/classic/source/_includes/sidebars/sections/google_plus.html
@@ -1,4 +1,5 @@
 {% if site.google_plus_user %}
-<a href="https://plus.google.com/{{ site.google_plus_user }}?rel=author"><img src="https://ssl.gstatic.com/images/icons/gplus-{{ site.google_plus_image_size}}.png" alt="Google Plus icon"></a>
+  <a href="https://plus.google.com/{{ site.google_plus_user }}?rel=author"{% if site.google_plus_hidden %} class="googleplus-hidden"{% endif %}>
+    <img src="https://ssl.gstatic.com/images/icons/gplus-{{ site.google_plus_image_size}}.png" alt="Google Plus icon">
+  </a>
 {% endif %}
-


### PR DESCRIPTION
Google_plus_hidden is broken in branch 2.1, but CSS class `.googleplus-hidden` is still there.
