### PR TITLE
Fixed blockquote plugin (author alone would not show up without title)

### DIFF
--- a/plugins/blockquote.rb
+++ b/plugins/blockquote.rb
@@ -21,6 +21,7 @@ module Jekyll
   class Blockquote < Liquid::Block
     FullCiteWithTitle = /(\S.*)\s+(https?:\/\/)(\S+)\s+(.+)/i
     FullCite = /(\S.*)\s+(https?:\/\/)(\S+)/i
+    AuthorTitle = /([^,]+),([^,]+)/
     Author =  /(.+)/
 
     def initialize(tag_name, markup, tokens)
@@ -34,13 +35,11 @@ module Jekyll
       elsif markup =~ FullCite
         @by = $1
         @source = $2 + $3
+      elsif markup =~ AuthorTitle
+        @by = $1
+        @title = $2.titlecase
       elsif markup =~ Author
-        if $1 =~ /([^,]+),([^,]+)/
-          @by = $1
-          @title = $2.titlecase
-        else
-          @by = $1
-        end
+        @by = $1
       end
       super
     end


### PR DESCRIPTION
Love your software, you're doing a great job with it. I just started using it two days ago, for blog.code-box.org, and found a minor bug that I thought I'd patch and submit back to you. Let me know what you think.

The bug is in your blockquote plugin. The author will not show up if you just provide the author and nothing else.
