### PR TITLE
Add Amazon S3 deploy option to rake tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
   gem 'rb-fsevent', '~> 0.9'
   gem 'stringex', '~> 1.4.0'
   gem 'liquid', '~> 2.3.0'
-  gem 'aws-sdk', '~> 1.8.0'
+  gem 'aws-sdk', '~> 1.8.1'
 end
 
 gem 'sinatra', '~> 1.3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     RedCloth (4.2.9)
-    aws-sdk (1.8.0)
-      httparty (~> 0.7)
+    aws-sdk (1.8.1.1)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
       uuidtools (~> 2.1)
@@ -18,9 +17,6 @@ GEM
     fast-stemmer (1.0.1)
     fssm (0.2.9)
     haml (3.1.7)
-    httparty (0.10.0)
-      multi_json (~> 1.0)
-      multi_xml
     jekyll (0.12.0)
       classifier (~> 1.3)
       directory_watcher (~> 1.1)
@@ -33,8 +29,6 @@ GEM
     liquid (2.3.0)
     maruku (0.6.1)
       syntax (>= 1.0.0)
-    multi_json (1.5.0)
-    multi_xml (0.5.2)
     nokogiri (1.5.6)
     posix-spawn (0.3.6)
     pygments.rb (0.3.4)
@@ -63,7 +57,7 @@ PLATFORMS
 
 DEPENDENCIES
   RedCloth (~> 4.2.9)
-  aws-sdk (~> 1.8.0)
+  aws-sdk (~> 1.8.1)
   compass (~> 0.12.2)
   haml (~> 3.1.7)
   jekyll (~> 0.12)

--- a/Rakefile
+++ b/Rakefile
@@ -267,6 +267,23 @@ multitask :push do
   end
 end
 
+desc "Configure Amazon S3 for website hosting"
+task :s3_init do
+  puts "## Configuring Amazon S3 bucket \"#{s3_bucket}\" for website hosting"
+  s3 = AWS::S3.new
+  puts "\n## Creating bucket"
+  bucket = s3.buckets.create s3_bucket
+  puts "\n## Enabling static website hosting"
+  bucket.configure_website do |cfg|
+    cfg.index_document_suffix = "index.html"
+  end
+  puts "\n## Enable read access to all resources"
+  bucket.policy = AWS::S3::Policy.new do |p|
+    p.allow(:actions => ["s3:GetObject"], :resources => ["arn:aws:s3:::#{s3_bucket}/*"], :principals => ["*"])
+  end
+  puts "\n## Website is hosted at http://#{s3_bucket}.s3-website-us-east-1.amazonaws.com"
+end
+
 desc "Deploy public directory to Amazon S3"
 task :s3 do
   puts "## Checking AWS Credentials..."


### PR DESCRIPTION
- Jekyll: a static-site generator
- Amazon S3: allows easy static-site web hosting
- Octopress + S3 Deploy Task: An awesome way to deploy an awesome site to an awesome hosting platform

There are (small) data transfer fees which hopefully anyone using S3 is aware of, but I'll provide the [pricing reference](http://aws.amazon.com/s3/#pricing) here to be helpful.
