### PR TITLE
Allow users to set a default for publish status when creating new posts/pages

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,6 +26,7 @@ themes_dir      = ".themes"   # directory for blog files
 new_post_ext    = "markdown"  # default new post file extension when using the new_post task
 new_page_ext    = "markdown"  # default new page file extension when using the new_page task
 server_port     = "4000"      # port for preview server eg. localhost:4000
+publish_default = "false"     # default published status for new posts and pages
 
 
 desc "Initial setup for Octopress: copies the default theme into the path of Jekyll's generator. Rake install defaults to rake install[classic] to install a different theme run rake install[some_theme_name]"
@@ -110,6 +111,7 @@ task :new_post, :title do |t, args|
     post.puts "title: \"#{title.gsub(/&/,'&amp;')}\""
     post.puts "date: #{Time.now.strftime('%Y-%m-%d %H:%M')}"
     post.puts "comments: true"
+    post.puts "published: #{publish_default}"
     post.puts "categories: "
     post.puts "---"
   end
@@ -147,6 +149,7 @@ task :new_page, :filename do |t, args|
       page.puts "comments: true"
       page.puts "sharing: true"
       page.puts "footer: true"
+      page.puts "published: #{publish_default}"
       page.puts "---"
     end
   else


### PR DESCRIPTION
Default option allows for setting new posts and pages to be `published: false` by default. When I write, I always start as a draft and only publish when it's done. Normally, the localhost server is fine for that, but sometimes I have multiple drafts going and it would be easy to get confused if I don't remember to change the setting in each individual post/page.
