### PR TITLE
To fix compass clean, which will cause rake clean/generate block

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,4 +1,4 @@
-$:.unshift File.expand_path(File.dirname(__FILE__), %w{ lib }) # For use/testing when no gem is installed
+$:.unshift File.expand_path("lib", File.dirname(__FILE__)) # For use/testing when no gem is installed
 require "octopress"
 
 config = Octopress::Configuration.read_configuration


### PR DESCRIPTION
It takes me 2 hours to fix...

c:\git\octopress>compass clean
TypeError on line ["1"] of c: can't convert Array into String
Run with --trace to see the full backtrace
