### PR TITLE
Missing slash in category_dir

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,7 @@ source: source
 destination: public
 plugins: plugins
 code_dir: downloads/code
-category_dir: blog/categories
+category_dir: /blog/categories
 markdown: rdiscount
 pygments: false # default python pygments have been replaced by pygments.rb
 


### PR DESCRIPTION
Need / at the beginning of the category_dir otherwise the href of the canonical tag is wrong. [Octopress site example](http://octopress.org/blog/categories/release/) 
