### PR TITLE
Generate can fail if Pygments can't parse a code block

### DIFF
--- a/plugins/pygments_code.rb
+++ b/plugins/pygments_code.rb
@@ -23,8 +23,8 @@ module HighlightCode
       else
         begin
           highlighted_code = Pygments.highlight(code, :lexer => lang, :formatter => 'html', :options => {:encoding => 'utf-8'})
-        rescue Exception => e
-          highlighted_code = Pygments.highlight(code, :lexer => 'text', :formatter => 'html', :options => {:encoding => 'utf-8'})
+        rescue MentosError
+          raise "Pygments can't parse unknown language: #{lang}."
         end
         File.open(path, 'w') {|f| f.print(highlighted_code) }
       end


### PR DESCRIPTION
Currently, the entire generate task will fail if the user has asked Pygments to parse a language block it doesn't understand -- this can be due to a type, omitting the language, etc. 

I think it's better to simply parse these blocks as plaintext in that case. 
