### PR TITLE
Async load of Facebook JS

### DIFF
--- a/.themes/classic/source/_includes/facebook_like.html
+++ b/.themes/classic/source/_includes/facebook_like.html
@@ -3,7 +3,7 @@
 <script>(function(d, s, id) {
   var js, fjs = d.getElementsByTagName(s)[0];
   if (d.getElementById(id)) {return;}
-  js = d.createElement(s); js.id = id;
+  js = d.createElement(s); js.id = id; js.async = true;
   js.src = "//connect.facebook.net/en_US/all.js#appId=212934732101925&xfbml=1";
   fjs.parentNode.insertBefore(js, fjs);
 }(document, 'script', 'facebook-jssdk'));</script>


### PR DESCRIPTION
added async = true to loader script.
According to Google PageSpeed the Facebook JS was not loaded async which blocks rendering of the page as long as the JS isn't fully loaded.
