### PR TITLE
Set title var earlier so that page title is not all lowercase

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -121,9 +121,9 @@ task :new_page, :filename do |t, args|
   raise "### You haven't set anything up yet. First run `rake install` to set up an Octopress theme." unless File.directory?(source_dir)
   args.with_defaults(:filename => 'new-page')
   page_dir = [source_dir]
+  title = args.filename
   if args.filename.downcase =~ /(^.+\/)?(.+)/
     filename, dot, extension = $2.rpartition('.').reject(&:empty?)         # Get filename and extension
-    title = filename
     page_dir.concat($1.downcase.sub(/^\//, '').split('/')) unless $1.nil?  # Add path to page_dir Array
     if extension.nil?
       page_dir << filename


### PR DESCRIPTION
Maybe not the right way to do this, but the title on pages is always all lowercase. Hacked my instance to set the title variable before `args.filename.downcase` lowercases the title.
