### PR TITLE
Fixes Gist Width

### DIFF
--- a/.themes/classic/sass/partials/_syntax.scss
+++ b/.themes/classic/sass/partials/_syntax.scss
@@ -259,3 +259,7 @@ figure.code {
   text-shadow: #cbcccc 0 1px 0;
   padding-left: 3em;
 }
+
+.gist .gist-file .gist-data .line-data {
+    width: 100%;
+}


### PR DESCRIPTION
The width of the gist looked wonky. Tried setting the width of the table to
100%, but it messes up the width of the line-numbers. Setting the width on
the line-data seems to work just fine though.
