### PR TITLE
Transition missed _config.yml changes to new _config files

### DIFF
--- a/_config/defaults/classic.yml
+++ b/_config/defaults/classic.yml
@@ -23,8 +23,13 @@ category_feeds: false
 # RSS feeds can list your email address if you like
 email:
 
-excerpt_link: "Read on &rarr;"  # "Continue reading" link text at the bottom of excerpted articles
 titlecase: true       # Converts page and post titles to titlecase
+
+# To change the layout's default sidebar Add a new sidebar source/_includes/sidebars/your_sidebar.html
+# then make changes below, eg. post_sidebar: your_sidebar.html
+blog_index_sidebar: blog_index_default.html
+page_sidebar: page_default.html
+post_sidebar: post_default.html
 
 paginate: 10          # Posts per page on the blog index
 pagination_dir: blog  # Directory base for pagination URLs eg. /blog/page/2/

--- a/_config/defaults/disqus.yml
+++ b/_config/defaults/disqus.yml
@@ -5,3 +5,4 @@
 
 disqus_short_name:
 disqus_show_comment_count: false
+disqus_developer: 0

--- a/_config/defaults/google_plus.yml
+++ b/_config/defaults/google_plus.yml
@@ -6,3 +6,4 @@
 # Hidden: No visible button, just add author information to search results
 googleplus_user:
 googleplus_hidden: false
+google_plus_image_size: 32

--- a/_config/defaults/jekyll.yml
+++ b/_config/defaults/jekyll.yml
@@ -11,7 +11,16 @@ destination:  public          # compiled site directory
 plugins:      plugins
 code_dir:     downloads/code
 category_dir: blog/categories
-markdown:     rdiscount
+include:
+  - .htaccess
+markdown:     redcarpet
+redcarpet:
+  extensions:
+    - no_intra_emphasis
+    - strikethrough
+    - autolink
+    - superscript
+    - smart
 pygments:     false           # Jekyll's default Python Pygments have been replaced by pygments.rb.
                               # Set to true to use Albino + Python Pygments
 

--- a/_config/defaults/sharing_buttons.yml
+++ b/_config/defaults/sharing_buttons.yml
@@ -3,6 +3,10 @@
 #   Post/Page Share Configuration   #
 # --------------------------------- #
 
+# Javascript social buttons often generate lots of http requests and may track your viewer's browsing history
+# Show respect for privacy and bandwidth with simple links for Twitter, Facebook and Google Plus.
+respectfully_social: true
+
 # Facebook Like
 facebook_like: false
 


### PR DESCRIPTION
With the transition to the new "_config" directory structure, some of the intermediate changes from _config.yml were missed. Integrating all missed changes based on _config.yml @9659a45 (predecessor to 6ce4d89). 
- _config/defaults/classic.yml: Add missed blog_index_sidebar, page_sidebar, post_sidebar entries; remove duplicate excerpt_link entry.
- _config/defaults/disqus.yml: Add missed disqus_developer entry.
- _config/defaults/google_plus.yml: Add missed google_plus_image_size entry.
- _config/defaults/jekyll.yml: Add missed include entry; add missed markdown=redcarpet and supporting entries.
- _config/defaults/sharing_buttons.yml: Add missed respectfully_social entry.
