### PR TITLE
Fix sidebars on 2.1.

### DIFF
--- a/_config/defaults/sidebar_layout.yml
+++ b/_config/defaults/sidebar_layout.yml
@@ -1,0 +1,12 @@
+---
+# ------------------- #
+#   Sidebar Layouts   #
+# ------------------- #
+
+
+# To change the layout's default sidebar, add a new sidebar
+# source/_includes/sidebars/your_sidebar.html
+# then make changes below, eg. post_sidebar: your_sidebar.html
+blog_index_sidebar: blog_index_default.html
+page_sidebar: page_default.html
+post_sidebar: post_default.html


### PR DESCRIPTION
This change adds some config keys lifted from the 2.0 `_config.yml` file.

Without these keys, the sidebar for each blog post says

```
Included file 'sidebars/' not found in _includes directory
```

This appears to be the same bug reported by https://twitter.com/digitadventures/status/295337631804448768

Please consider merging this patch for the benefit of other 2.1 bleeding edge testers :)

Thank you very, very much for Octopress!
