### PR TITLE
Fix the issue that config in site.yml won't override default ones.

### DIFF
--- a/lib/octopress/configuration.rb
+++ b/lib/octopress/configuration.rb
@@ -46,13 +46,13 @@ module Octopress
     # Returns a Hash of all the configuration files, with each key being a symbol
     def self.read_configuration
       configs = {}
-      Dir.glob(self.config_dir('defaults', '**', '*.yml')) do |filename|
+      Dir.glob(self.config_dir('*.yml')) do |filename|
         file_yaml = YAML.load(File.read(filename))
         unless file_yaml.nil?
           configs = file_yaml.deep_merge(configs)
         end
       end
-      Dir.glob(self.config_dir('*.yml')) do |filename|
+      Dir.glob(self.config_dir('defaults', '**', '*.yml')) do |filename|
         file_yaml = YAML.load(File.read(filename))
         unless file_yaml.nil?
           configs = file_yaml.deep_merge(configs)


### PR DESCRIPTION
#958 creates a new layout, however `site.yml` and `deploy.yml` won't override default options. Here is a patch to fix it.

@parkr do you agree?
