### PR TITLE
Add Goolge+ author information with <link> inside of <head>

### DIFF
--- a/.themes/classic/source/_includes/head.html
+++ b/.themes/classic/source/_includes/head.html
@@ -6,6 +6,7 @@
   <meta charset="utf-8">
   <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
   <meta name="author" content="{{ site.author }}">
+  {% if site.googleplus_user %}<link href="https://plus.google.com/{{ site.googleplus_user }}" rel="author">{% endif %}
 
   {% capture description %}{% if page.description %}{{ page.description }}{% else %}{{ content | raw_content }}{% endif %}{% endcapture %}
   <meta name="description" content="{{ description | strip_html | condense_spaces | truncate:150 }}">


### PR DESCRIPTION
You can also use `<link rel="auhtor" href="https://plus.google.com/[...]">` inside of `<head>` to link to your Goolge+ profile and get author information in search results.

This way you don't have to put a visible Goolge+ button on your blog if you don't want to.
