### PR TITLE
Use the Github API repo sorting.

### DIFF
--- a/.themes/classic/source/javascripts/github.js
+++ b/.themes/classic/source/javascripts/github.js
@@ -13,7 +13,7 @@ var github = (function(){
   return {
     showRepos: function(options){
       $.ajax({
-          url: "https://api.github.com/users/"+options.user+"/repos?callback=?"
+          url: "https://api.github.com/users/"+options.user+"/repos?sort=pushed;callback=?"
         , type: 'jsonp'
         , error: function (err) { $(options.target + ' li.loading').addClass('error').text("Error loading feed"); }
         , success: function(data) {
@@ -23,14 +23,6 @@ var github = (function(){
             if (options.skip_forks && data.data[i].fork) { continue; }
             repos.push(data.data[i]);
           }
-          repos.sort(function(a, b) {
-            var aDate = new Date(a.pushed_at).valueOf(),
-                bDate = new Date(b.pushed_at).valueOf();
-
-            if (aDate === bDate) { return 0; }
-            return aDate > bDate ? -1 : 1;
-          });
-
           if (options.count) { repos.splice(options.count); }
           render(options.target, repos);
         }


### PR DESCRIPTION
The Github API can sort by pushed time, no need to do it manually.
http://developer.github.com/v3/repos/#list-user-repositories

This is both more efficient, Github does the sorting, but it also
fixes a bug.  Because the list of results are paginated, if you have
more than a page's worth of repositories it will only sort that page.
This results in a false view of what has been recently pushed.

For a good example, try my github account "schwern" with and
without this patch.
