### PR TITLE
Added .gitattributes to avoid CRLFs in the codebase.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
I've use the same `.gitattributes` file as the [Yeoman.io](https://github.com/yeoman/yeoman/blob/master/.gitattributes) project does.
