### PR TITLE
Add 'clobber' task for purging generated files.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -223,6 +223,11 @@ task :clean do
   puts "## Cleaned Sass, Pygments and Gist caches, removed generated stylesheets ##"
 end
 
+desc "Remove generated files (#{configuration[:destination]} directory)."
+task :clobber do
+  rm_rf [configuration[:destination]]
+end
+
 desc "Update theme source and style"
 task :update, :theme do |t, args|
   theme = args.theme || 'classic'


### PR DESCRIPTION
I've found this handy on occasion, when I'm hacking on Octopress itself and want to be certain a change I made works and doesn't merely appear to work.
