### PR TITLE
Fix static reference to instance method in Compass' config.

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,7 +1,7 @@
 $:.unshift File.expand_path("lib", File.dirname(__FILE__)) # For use/testing when no gem is installed
 require "octopress"
 
-config = Octopress::Configuration.read_configuration
+config = Octopress::Configuration.new.read_configuration
 
 project_type = :stand_alone
 


### PR DESCRIPTION
Fixes a show-stopper issue in 2.1 preventing things from working at all.
