### PR TITLE
Bump Rack version to leverage security fixes.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "http://rubygems.org"
 
 group :development do
   gem 'rake', '~> 10.0.3'
-  gem 'rack', '~> 1.4.1'
+  gem 'rack', '~> 1.5.0'
   gem 'jekyll', '~> 0.12.0'
   gem 'redcarpet', '~> 2.2.2'
   gem 'pygments.rb', '~> 0.3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
     pygments.rb (0.3.4)
       posix-spawn (~> 0.3.6)
       yajl-ruby (~> 1.1.0)
-    rack (1.4.1)
+    rack (1.5.2)
     rack-protection (1.3.2)
       rack
     rake (10.0.3)
@@ -70,7 +70,7 @@ DEPENDENCIES
   jekyll (~> 0.12.0)
   liquid (~> 2.3.0)
   pygments.rb (~> 0.3.4)
-  rack (~> 1.4.1)
+  rack (~> 1.5.0)
   rake (~> 10.0.3)
   rake-minify
   rb-fsevent (~> 0.9.3)


### PR DESCRIPTION
Not immensely relevant for development mode of course, but for people running the Sinatra server for deployments (say, mixed static site with some dynamic functionality), might as well keep up with security.
