### PR TITLE
Removal of apparently unreferenced, dangling method.

### DIFF
--- a/plugins/category_generator.rb
+++ b/plugins/category_generator.rb
@@ -208,7 +208,3 @@ HTML
   end
 
 end
-
-    def parse_category
-      { slug: slug, title: title }
-    end


### PR DESCRIPTION
A search of the code reveals no reference to 'parse_category', and it's placement/indentation implies it's the result of a bad merge or some such...
