### PR TITLE
Compass rigor.

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -3,6 +3,7 @@ require "octopress"
 
 config = Octopress::Configuration.new.read_configuration
 
+project_path = File.dirname(__FILE__)
 project_type = :stand_alone
 
 compass_http_path = config[:destination].gsub('public', '')


### PR DESCRIPTION
Certain Jekyll plugins manage to confuse compass by changing the CWD -- this prevents that with no apparent breakage to anything else.
