### PR TITLE
Make FB JS load synchronously so it doesn't block page rendering.

### DIFF
--- a/.themes/classic/source/_includes/facebook_like.html
+++ b/.themes/classic/source/_includes/facebook_like.html
@@ -3,7 +3,7 @@
 <script type="text/javascript">(function(d, s, id) {
   var js, fjs = d.getElementsByTagName(s)[0];
   if (d.getElementById(id)) {return;}
-  js = d.createElement(s); js.id = id;
+  js = d.createElement(s); js.id = id; js.async = true;
   js.src = "//connect.facebook.net/en_US/all.js#appId=212934732101925&xfbml=1";
   fjs.parentNode.insertBefore(js, fjs);
 }(document, 'script', 'facebook-jssdk'));</script>


### PR DESCRIPTION
Same change as https://github.com/imathis/octopress/pull/991 but on the 2.1 branch.  Works like a charm.
