### PR TITLE
Ruby 1.9.2's minitest doesn't support 'subject'.  So, use the gem.

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -3,5 +3,8 @@ source "https://rubygems.org"
 gem "rake", "~> 10.0"
 
 group :test do
-  gem "rspec"
+  # Yes, minitest is part of Ruby 1.9, but certain features we use such as 'subject'
+  # in spec-style tests weren't in the version that shipped with 1.9.2.  To deal
+  # with this, we use the gem version.
+  gem "minitest"
 end

--- a/lib/Gemfile.lock
+++ b/lib/Gemfile.lock
@@ -1,20 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.1.3)
+    minitest (4.6.2)
     rake (10.0.3)
-    rspec (2.12.0)
-      rspec-core (~> 2.12.0)
-      rspec-expectations (~> 2.12.0)
-      rspec-mocks (~> 2.12.0)
-    rspec-core (2.12.2)
-    rspec-expectations (2.12.1)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.12.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  minitest
   rake (~> 10.0)
-  rspec


### PR DESCRIPTION
Works gracefully with 1.9.2 AND 1.9.3.

(I noticed the Travis builds failing on just 1.9.2...)
