### PR TITLE
Cleanup configuration mechanisms a bit.

### DIFF
--- a/_config/defaults/assets.yml
+++ b/_config/defaults/assets.yml
@@ -1,0 +1,14 @@
+---
+assets:
+  #
+  # Include source line comments in compiled SASS?
+  #
+  line_comments: true
+  #
+  # Compass CSS minification behavior.  Values are:
+  # * nested
+  # * expanded (recommended for development)
+  # * compact
+  # * compressed (recommended for production)
+  #
+  output_style: compressed

--- a/config.rb
+++ b/config.rb
@@ -18,5 +18,5 @@ images_dir = "#{config[:source]}/images"
 fonts_dir = "#{config[:source]}/fonts"
 generated_images_dir = "#{config[:source]}/images"
 
-line_comments = false
-output_style = :compressed
+line_comments = config[:assets][:line_comments]
+output_style = config[:assets][:output_style].to_sym

--- a/config.ru
+++ b/config.ru
@@ -1,8 +1,7 @@
 require 'bundler/setup'
 require 'sinatra/base'
 
-# The project root directory
-$root = ::File.dirname(__FILE__)
+require File.expand_path(File.join(File.dirname(__FILE__), 'lib/octopress'))
 
 class SinatraStaticServer < Sinatra::Base
 
@@ -15,7 +14,7 @@ class SinatraStaticServer < Sinatra::Base
   end
 
   def send_sinatra_file(path, &missing_file_block)
-    file_path = File.join(File.dirname(__FILE__), 'public',  path)
+    file_path = File.join(File.dirname(__FILE__), Octopress.configuration[:destination],  path)
     file_path = File.join(file_path, 'index.html') unless file_path =~ /\.[a-z]+$/i
     File.exist?(file_path) ? send_file(file_path) : missing_file_block.call
   end

--- a/lib/octopress/configuration.rb
+++ b/lib/octopress/configuration.rb
@@ -19,7 +19,7 @@ module Octopress
     #
     # Returns a Hash of the items in the configuration file (symbol keys)
     def read_config(path)
-      full_path = self.config_dir(path)
+      full_path = path.start_with?('/') ? path : self.config_dir(path)
       if File.exists? full_path
         begin
           configs = YAML.load(File.open(full_path))
@@ -54,16 +54,12 @@ module Octopress
     def read_configuration
       configs = {}
       Dir.glob(self.config_dir('defaults', '**', '*.yml')) do |filename|
-        file_yaml = YAML.load(File.read(filename))
-        unless file_yaml.nil?
-          configs = file_yaml.deep_merge(configs)
-        end
+        file_yaml = read_config(filename)
+        configs = file_yaml.deep_merge(configs)
       end
       Dir.glob(self.config_dir('*.yml')) do |filename|
-        file_yaml = YAML.load(File.read(filename))
-        unless file_yaml.nil?
-          configs = configs.deep_merge(file_yaml)
-        end
+        file_yaml = read_config(filename)
+        configs = configs.deep_merge(file_yaml)
       end
 
       configs.to_symbol_keys

--- a/lib/octopress/core_ext.rb
+++ b/lib/octopress/core_ext.rb
@@ -1,3 +1,20 @@
+module Octopress
+  module HashHelpers
+    def self.transform_keys_recursively(entity, &block)
+      result = entity
+      case entity
+      when Hash
+        result = Hash[entity.map do |key, value|
+          [block.call(key), self.transform_keys_recursively(value, &block)]
+        end]
+      when Array
+        result = entity.map { |elem| self.transform_keys_recursively(elem, &block) }
+      end
+      return result
+    end
+  end
+end
+
 class Hash
   # Merges self with another hash, recursively.
   #
@@ -18,9 +35,9 @@ class Hash
     target
   end
   def to_symbol_keys
-    inject({}) { |memo,(k,v)| memo[k.to_sym] = v; memo }
+    Octopress::HashHelpers.transform_keys_recursively(self, &:to_sym)
   end
   def to_string_keys
-    inject({}) { |memo,(k,v)| memo[k.to_s] = v; memo }
+    Octopress::HashHelpers.transform_keys_recursively(self, &:to_s)
   end
 end

--- a/lib/spec/octopress/core_ext_spec.rb
+++ b/lib/spec/octopress/core_ext_spec.rb
@@ -1,0 +1,97 @@
+require 'minitest/autorun'
+require_relative '../../octopress'
+
+describe Hash do
+  # Using functions here because it's easy to ensure we get fresh instances all
+  # the way down the hierarchy this way -- and we can produce both input, and
+  # expected output data cleanly while ensuring they stay in sync.
+  def create_complex_array(mode)
+    case mode
+    when :mixed
+      keys = ['a_string_sub_hash_key', :a_symbol_sub_hash_with]
+    when :symbols
+      keys = [:a_string_sub_hash_key, :a_symbol_sub_hash_with]
+    when :strings
+      keys = ['a_string_sub_hash_key', 'a_symbol_sub_hash_with']
+    end
+
+    array = [
+      # Some miscellaneous types just to ensure we don't choke on random things...
+      nil,
+      false,
+      true,
+      1,
+      {
+        keys[0] => 1,
+        keys[1] => 1,
+      },
+    ]
+  end
+
+  def create_complex_hash(mode)
+    case mode
+    when :mixed
+      keys = [
+        "a_string_hash_key",
+        :a_symbol_hash_key,
+        "another_string_hash_key",
+        :another_symbol_hash_key,
+      ]
+    when :symbols
+      keys = [
+        :a_string_hash_key,
+        :a_symbol_hash_key,
+        :another_string_hash_key,
+        :another_symbol_hash_key,
+      ]
+    when :strings
+      keys = [
+        "a_string_hash_key",
+        "a_symbol_hash_key",
+        "another_string_hash_key",
+        "another_symbol_hash_key",
+      ]
+    end
+
+    hash = {
+      keys[0] => {
+        keys[0] => 1,
+        keys[1] => 1,
+        keys[2] => create_complex_array(mode),
+        keys[3] => create_complex_array(mode),
+      },
+      keys[1] => {
+        keys[0] => 1,
+        keys[1] => 1,
+        keys[2] => create_complex_array(mode),
+        keys[3] => create_complex_array(mode),
+      },
+      keys[2] => create_complex_array(mode),
+      keys[3] => create_complex_array(mode),
+    }
+
+    return hash
+  end
+
+  describe '#to_symbol_keys' do
+    subject do
+      # Cover all sorts of permutations of structure here...
+      create_complex_hash(:mixed).to_symbol_keys
+    end
+
+    it "recursively converts hash keys into symbols" do
+      subject.must_equal create_complex_hash(:symbols)
+    end
+  end
+
+  describe '#to_string_keys' do
+    subject do
+      # Cover all sorts of permutations of structure here...
+      create_complex_hash(:mixed).to_string_keys
+    end
+
+    it "recursively converts hash keys into strings" do
+      subject.must_equal create_complex_hash(:strings)
+    end
+  end
+end


### PR DESCRIPTION
- Hoist a couple bits of config out of config.rb to keep configuration in one place.
- Make Sinatra use config instead of duplicating config setting via hard-coding.
- Make config hashes stringify/symbolify recursively (handy for namespacing).
- Make Octopress::Configuration use its own read_config method from read_configuration.
- Make read_config smarter about absolute vs. relative paths.
- Built test case around recursive stringification/symbolification of hash keys.

(Rebase of https://github.com/imathis/octopress/pull/1062 )
