### PR TITLE
Let me deploy to Github pages over HTTP as well as SSH

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -307,7 +307,7 @@ task :setup_github_pages, :repo do |t, args|
     puts "(For example, 'git@github.com:your_username/your_username.github.com)"
     repo_url = get_stdin("Repository url: ")
   end
-  user = repo_url.match(/:([^\/]+)/)[1]
+  user = repo_url.match(/github.com(:|\/)([^\/]+)/)[1]
   branch = (repo_url.match(/\/[\w-]+\.github\.com/).nil?) ? 'gh-pages' : 'master'
   project = (branch == 'gh-pages') ? repo_url.match(/\/([^\.]+)/)[1] : ''
   unless (`git remote -v` =~ /origin.+?octopress(?:\.git)?/).nil?


### PR DESCRIPTION
The regex that pulled usernames out of the repo URL assumed user entered the SSH url, and falls over ungracefully if I use an HTTP one. I want to push to GH pages from behind a nasty corporate firewall that doesn't let SSH out. I've tweaked the regex a bit.
