### PR TITLE
same minor "for example" fix, on correct branch

### DIFF
--- a/source/docs/deploying/rsync/index.markdown
+++ b/source/docs/deploying/rsync/index.markdown
@@ -66,4 +66,4 @@ git config branch.master.remote origin
 
 ## Deploying to a subdirectory
 
-If for you wanted to host an Octopress blog at `http://yoursite.com/blog/` you would need to configure Octopress for [deploying to a subdirectory](/docs/deploying/subdir).
+If, for example, you wanted to host an Octopress blog at `http://yoursite.com/blog/` you would need to configure Octopress for [deploying to a subdirectory](/docs/deploying/subdir).


### PR DESCRIPTION
I think the same minor typo fix submitted on the wrong branch previously.
