### PR TITLE
Make compiled scss debuggable when previewing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -60,9 +60,9 @@ desc "Watch the site and regenerate when it changes"
 task :watch do
   raise "### You haven't set anything up yet. First run `rake install` to set up an Octopress theme." unless File.directory?(source_dir)
   puts "Starting to watch source with Jekyll and Compass."
-  system "compass compile --css-dir #{source_dir}/stylesheets" unless File.exist?("#{source_dir}/stylesheets/screen.css")
+  system "compass compile --css-dir #{source_dir}/stylesheets --debug-info --output-style expanded" unless File.exist?("#{source_dir}/stylesheets/screen.css")
   jekyllPid = Process.spawn({"OCTOPRESS_ENV"=>"preview"}, "jekyll --auto")
-  compassPid = Process.spawn("compass watch")
+  compassPid = Process.spawn("compass watch --debug-info --output-style expanded")
 
   trap("INT") {
     [jekyllPid, compassPid].each { |pid| Process.kill(9, pid) rescue Errno::ESRCH }


### PR DESCRIPTION
The Octopress configuration tells the scss to compile in a compressed
format, which is great for production. However, when developing a site
or a theme and previewing, it can be very helpful to be able to see the
compiled scss without all of the minification.

This commit sets, for the `preview` rake task, two options when calling
`compass compile` that should make working with scss a little easier for
developers. The first is `--debug-info` which includes metadata about
each selector that Chrome developer tools can use to give you more
information about the actual source of the style. The second is
`--output-style expanded` which prevents the minification step from
happening, allowing you to view the compiled CSS in a more readable
state.
