### PR TITLE
Change kill signal so grandchildren processes end.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -158,7 +158,7 @@ task :preview do
   rackupPid = Process.spawn("rackup --host #{configuration[:server_host]} --port #{configuration[:server_port]}")
 
   trap("INT") {
-    [guardPid, rackupPid].each { |pid| Process.kill(9, pid) rescue Errno::ESRCH }
+    [guardPid, rackupPid].each { |pid| Process.kill(3, pid) rescue Errno::ESRCH }
     exit 0
   }
 


### PR DESCRIPTION
Brought up in issue #1119. This fixes the problem of the lingering process, but is a bit hacky. Thoughts?
