### PR TITLE
Enable inline PHP syntax highlighting

### DIFF
--- a/plugins/pygments_code.rb
+++ b/plugins/pygments_code.rb
@@ -22,14 +22,14 @@ module HighlightCode
         highlighted_code = File.read(path)
       else
         begin
-          highlighted_code = Pygments.highlight(code, :lexer => lang, :formatter => 'html', :options => {:encoding => 'utf-8'})
+          highlighted_code = Pygments.highlight(code, :lexer => lang, :formatter => 'html', :options => {:encoding => 'utf-8', :startinline => true})
         rescue MentosError
           raise "Pygments can't parse unknown language: #{lang}."
         end
         File.open(path, 'w') {|f| f.print(highlighted_code) }
       end
     else
-      highlighted_code = Pygments.highlight(code, :lexer => lang, :formatter => 'html', :options => {:encoding => 'utf-8'})
+      highlighted_code = Pygments.highlight(code, :lexer => lang, :formatter => 'html', :options => {:encoding => 'utf-8', :startinline => true})
     end
     highlighted_code
   end


### PR DESCRIPTION
Pygments has a "startinline" option which is only relevant for the PhpLexer. It allows syntax highlighting without the opening <?php tag. I believe this option is ignored for every other lexer.

You can view the Pygments documentation on it here: http://pygments.org/docs/lexers/ Search the page for startinline to jump right to it.

Could you either set this to true by default using the proposed change? Or could this be exposed as a setting somewhere in _config.yml? I can't think of a reason someone would not want this enabled.
