### PR TITLE
Rake task to backup your project to a git repository

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,12 @@ deploy_default = "rsync"
 # This will be configured for you when you run config_deploy
 deploy_branch  = "gh-pages"
 
+## -- Backup Configs -- ##
+
+bk_remote      = "backup" # Your remote backup repo name
+bk_repo        = "git@github.com:johnsmith/blog_backup.git" # Your remote backup repository url
+bk_branch      = "master" # Your remote backup branch
+
 ## -- Misc Configs -- ##
 
 public_dir      = "public"    # compiled site directory
@@ -204,6 +210,46 @@ task :update_source, :theme do |t, args|
   mv "#{source_dir}/index.html", "#{blog_index_dir}", :force=>true if blog_index_dir != source_dir
   cp "#{source_dir}.old/index.html", source_dir if blog_index_dir != source_dir && File.exists?("#{source_dir}.old/index.html")
   puts "## Updated #{source_dir} ##"
+end
+
+###########
+# Back Up #
+###########
+
+namespace :backup do
+
+  desc "Configure your source backup git repository"
+  task :config do
+    unless bk_remote.empty? || bk_repo.empty? || bk_branch.empty?
+      unless `git remote`.include? bk_remote
+        puts "\n## Adding new git remote #{bk_remote} for backup."
+        system "git remote add #{bk_remote} #{bk_repo}"
+      else
+        puts "\n## You already have a remote called #{bk_remote}.\n## Update your rake file or use `rake backup:push` to backup your project."
+      end
+    else
+      puts "\nOne of your backup configurations is empty."
+    end
+  end
+
+  desc "Backup your source to a remote git repository"
+  task :push do
+    unless bk_remote.empty? || bk_repo.empty? || bk_branch.empty?
+      if `git remote`.include? bk_remote
+        system "git add ."
+        system "git add -u"
+        puts "\n## Commiting: Site backed up to #{bk_branch} on #{bk_repo} at #{Time.now.utc}"
+        message = "Site backed up at #{Time.now.utc}"
+        system "git commit -m \"#{message}\""
+        system "git push #{bk_remote} #{bk_branch} --force"
+      else
+        puts "\n## Run `rake backup:config` to setup your backup git repository first."
+      end
+    else
+      puts "\nOne of your backup configurations is empty."
+    end
+  end
+
 end
 
 ##############


### PR DESCRIPTION
There's currently no automated method for backing up your project's source.  This change would enable the user to configure a separate remote that can be used to do just that.  Two rake tasks handle creating the git remote and adding, committing and pushing to it.
## Three new options:
- bk_remote - Your remote backup repo name `git remote add ...`
- bk_repo - Your remote backup repo url
- bk_branch - Your remote backup branch
## Two new tasks under the `backup` namespace:
- config - Creates the remote given the options listed in your Rakefile (bk_remote, bk_repo, bk_branch)
- push - Adds, commits and pushes any changes to your backup repository
