### PR TITLE
Video tag and relative paths

### DIFF
--- a/plugins/video_tag.rb
+++ b/plugins/video_tag.rb
@@ -22,11 +22,11 @@ module Jekyll
     @width = ''
 
     def initialize(tag_name, markup, tokens)
-      if markup =~ /(https?:\S+)(\s+(https?:\S+))?(\s+(https?:\S+))?(\s+(\d+)\s(\d+))?(\s+(https?:\S+))?/i
-        @video  = [$1, $3, $5].compact
-        @width  = $7
-        @height = $8
-        @poster = $10
+      if markup =~ /^\s*(\S+)(\s+\S+)??(\s+\S+)??(?:\s+(\d+)\s+(\d+))?+(\s+\S+)?\s*$/
+        @video  = [$1, $2, $3].compact
+        @width  = $4
+        @height = $5
+        @poster = $6
       end
       super
     end


### PR DESCRIPTION
The current video tag only works with full paths (containing http:// or https://), not supporting relative paths.

Using a combination of reluctant and greedy quantifiers, the provided video tag regex seems to work correctly with arbitrary paths over a variety of valid inputs. (Per the URI spec, a valid relative reference can be just about anything so this approach seems superior to the approach in image_tag.rb).
