### PR TITLE
Replaced regex that parses lang parameter in code block plugin

### DIFF
--- a/plugins/code_block.rb
+++ b/plugins/code_block.rb
@@ -56,9 +56,9 @@ module Jekyll
       @caption = nil
       @filetype = nil
       @highlight = true
-      if markup =~ /\s*lang:(\w+)/i
+      if markup =~ /lang:(\w+\-?\w*)/i
         @filetype = $1
-        markup = markup.sub(/lang:\w+/i,'')
+        markup = markup.sub(/lang:(\w+\-?\w*)/i,'')
       end
       if markup =~ CaptionUrlTitle
         @file = $1


### PR DESCRIPTION
According to the [Pygments Available lexers](http://pygments.org/docs/lexers/) page to highlight "C# within ASP.NET pages" we can use `aspx-cs` short name. As I understood code block plugin supports lexer short name using `lang` parameter. And there should be no issues with following code block:

``` xml
{% codeblock lang:aspx-cs %}
<asp:Label runat="server" Text='<%# Bind("LabelText") %>' />
{% endcodeblock %}
```

When generating using `rake generate` following error occurs:

``` cmd
Liquid Exception: Pygments can't parse unknown language: aspx. in 2013-03-30-aspx-codeblock-test.markdown
C:/dev/test-site/plugins/pygments_code.rb:27:in `rescue in pygments'
C:/dev/test-site/plugins/pygments_code.rb:24:in `pygments'
C:/dev/test-site/plugins/pygments_code.rb:14:in `highlight'
C:/dev/test-site/plugins/code_block.rb:82:in `render'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/liquid-2.3.0/lib/liquid/block.rb:94:in `block in render_all'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/liquid-2.3.0/lib/liquid/block.rb:92:in `collect'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/liquid-2.3.0/lib/liquid/block.rb:92:in `render_all'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/liquid-2.3.0/lib/liquid/block.rb:82:in `render'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/liquid-2.3.0/lib/liquid/template.rb:124:in `render'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/liquid-2.3.0/lib/liquid/template.rb:132:in `render!'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/jekyll-0.12.0/lib/jekyll/convertible.rb:79:in `do_layout'
C:/dev/amanek.com/plugins/post_filters.rb:167:in `do_layout'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/jekyll-0.12.0/lib/jekyll/post.rb:195:in `render'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/jekyll-0.12.0/lib/jekyll/site.rb:200:in `block in render'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/jekyll-0.12.0/lib/jekyll/site.rb:199:in `each'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/jekyll-0.12.0/lib/jekyll/site.rb:199:in `render'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/jekyll-0.12.0/lib/jekyll/site.rb:41:in `process'
C:/Ruby193/lib/ruby/gems/1.9.1/gems/jekyll-0.12.0/bin/jekyll:264:in `<top (required)>'
C:/Ruby193/bin/jekyll:23:in `load'
C:/Ruby193/bin/jekyll:23:in `<main>'
Build Failed
```

As you can see current regular expression (`/\s*lang:(\w+)/i`) in `plugins/code_block.rb` ( lines 59, 61) does not take into account possible dash in `lang` parameter.

To fix the bug it should be replaced with `/\s*lang:(\w+\-?\w*)/i`.
