### PR TITLE
Updated fix for Issue #662 - Title and link overlap on code_block

### DIFF
--- a/.themes/classic/sass/partials/_syntax.scss
+++ b/.themes/classic/sass/partials/_syntax.scss
@@ -225,7 +225,8 @@ figure.code {
   figcaption {
     position: relative;
     @extend .code-title;
-    a { @extend .download-source; }
+    a { position: relative;
+        @extend .download-source; }
   }
   .highlight {
     margin-bottom: 0;
@@ -251,11 +252,14 @@ figure.code {
 }
 
 .download-source {
-  position: absolute; right: .8em;
+  right: .8em;
   @include hover-link;
   color: #666 !important;
   z-index: 1;
   font-size: 13px;
   text-shadow: #cbcccc 0 1px 0;
-  padding-left: 3em;
+}
+
+.figfooter {
+  border-radius: 0px 0px 5px 5px !important;
 }

--- a/plugins/code_block.rb
+++ b/plugins/code_block.rb
@@ -54,6 +54,8 @@ module Jekyll
     def initialize(tag_name, markup, tokens)
       @title = nil
       @caption = nil
+      @linkTitle = nil
+      @linkUrl = nil
       @filetype = nil
       @highlight = true
       if markup =~ /\s*lang:(\w+)/i
@@ -62,7 +64,9 @@ module Jekyll
       end
       if markup =~ CaptionUrlTitle
         @file = $1
-        @caption = "<figcaption><span>#{$1}</span><a href='#{$2}'>#{$3 || 'link'}</a></figcaption>"
+        @linkUrl = $2
+        @linkTitle = $3
+        @caption = "<figcaption><span>#{$1}</span></figcaption>"
       elsif markup =~ Caption
         @file = $1
         @caption = "<figcaption><span>#{$1}</span></figcaption>\n"
@@ -79,10 +83,16 @@ module Jekyll
       source = "<figure class='code'>"
       source += @caption if @caption
       if @filetype
-        source += " #{highlight(code, @filetype)}</figure>"
+        source += " #{highlight(code, @filetype)}"
       else
-        source += "#{tableize_code(code.lstrip.rstrip.gsub(/</,'&lt;'))}</figure>"
+        source += "#{tableize_code(code.lstrip.rstrip.gsub(/</,'&lt;'))}"
       end
+      if !@linkTitle.nil?
+        source += "<figcaption class='figfooter'><a href='#{@linkUrl}'>#{@linkTitle}</a></figcaption>"
+      elsif !@linkUrl.nil?
+        source += "<figcaption class='figfooter'><a href='#{@linkUrl}'>link</a></figcaption>"
+      end
+      source += "</figure>"
       source = safe_wrap(source)
       source = context['pygments_prefix'] + source if context['pygments_prefix']
       source = source + context['pygments_suffix'] if context['pygments_suffix']


### PR DESCRIPTION
Title and link overlap on code_block like this:

http://dev02.williamcombs.com

I've relocated the link text and centered it on the bottom, and also rounded the bottom corners, you can see my fix here:

http://dev01.williamcombs.com

Thanks!
