### PR TITLE
Get 'Tweet' and 'Google +1' buttons back

### DIFF
--- a/.themes/classic/_config/twitter-timeline.yml
+++ b/.themes/classic/_config/twitter-timeline.yml
@@ -6,4 +6,4 @@
 twitter:
   user:
   # Sharing button on posts
-  # tweet-button: true
+  # tweet_button: true

--- a/.themes/classic/source/_includes/google_plus_one.html
+++ b/.themes/classic/source/_includes/google_plus_one.html
@@ -1,4 +1,4 @@
-{% if site.google_plus_one %}
+{% if site.googleplus.plus_one %}
   <script type="text/javascript">
     (function() {
       var script = document.createElement('script'); script.type = 'text/javascript'; script.async = true;

--- a/.themes/classic/source/_includes/post/sharing.html
+++ b/.themes/classic/source/_includes/post/sharing.html
@@ -1,5 +1,5 @@
 <div class="sharing">
-  {% if site.twitter_tweet_button %}
+  {% if site.twitter.tweet_button %}
     {% if site.respectfully_social %}
       <a href="http://twitter.com/share" title="Tweet this" class="twitter-share" target="_blank">Tweet</a>
     {% else %}
@@ -10,7 +10,7 @@
       {% endif %}
     {% endif %}
   {% endif %}
-  {% if site.google_plus_one %}
+  {% if site.googleplus.plus_one %}
     {% if site.respectfully_social %}
       <a title="+1 on Google Plus" class="googleplus-share" href="https://plusone.google.com/_/+1/confirm?hl=en&url={{site.url}}{{page.url}}" target="_blank">+1</a>
     {% else %}

--- a/.themes/classic/source/_includes/twitter_sharing.html
+++ b/.themes/classic/source/_includes/twitter_sharing.html
@@ -1,4 +1,4 @@
-{% if site.twitter_follow_button or site.twitter_tweet_button %}
+{% if site.twitter.follow_button or site.twitter.tweet_button %}
   <script type="text/javascript">
     (function(){
       var twitterWidgets = document.createElement('script');


### PR DESCRIPTION
The sharing widget is still using the old-style configuration keys **'twitter_tweet_button'** and **'google_plus_one'**, which don't exist anymore.

Changing them to **'twitter.tweet_button'** and **'googleplus.plus_one'** works.

PS: I also renamed **'tweet-button'** to **'tweet_button'** considering the naming convention.
