### PR TITLE
Make RSync deployments a bit safer by making deletion of defunct files h...

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -382,7 +382,7 @@ task :rsync do
     ""
   end
   document_root = ensure_trailing_slash(configuration[:document_root])
-  ok_failed system("rsync -avze 'ssh -p #{configuration[:ssh_port]} #{ssh_key}' #{exclude} #{configuration[:rsync_args]} #{"--delete" unless !configuration[:rsync_delete]} #{ensure_trailing_slash(configuration[:destination])} #{configuration[:ssh_user]}:#{document_root}")
+  ok_failed system("rsync -avze 'ssh -p #{configuration[:ssh_port]} #{ssh_key}' #{exclude} #{configuration[:rsync_args]} #{"--delete-after" unless !configuration[:rsync_delete]} #{ensure_trailing_slash(configuration[:destination])} #{configuration[:ssh_user]}:#{document_root}")
 end
 
 desc "deploy public directory to github pages"


### PR DESCRIPTION
...appen after everything else is updated.

This prevents a race condition where someone may get an old version of a page, and have dependent assets not exist.
