### PR TITLE
Fix some namespacing stuff, and a few other JS breakages.

### DIFF
--- a/.themes/classic/_config/google-plus.yml
+++ b/.themes/classic/_config/google-plus.yml
@@ -11,3 +11,4 @@ googleplus:
 
   # Google+ Sharing
   plus_one: false
+  plus_one_size: 32

--- a/.themes/classic/_config/twitter-timeline.yml
+++ b/.themes/classic/_config/twitter-timeline.yml
@@ -6,4 +6,4 @@
 twitter:
   user:
   # Sharing button on posts
-  # tweet-button: true
+  # tweet_button: true

--- a/.themes/classic/assets/javascripts/lib/octopress.js
+++ b/.themes/classic/assets/javascripts/lib/octopress.js
@@ -64,7 +64,7 @@ var octopress = (function(){
       $('video').each(function(i, video){
         video = $(video);
         if (!Modernizr.video.h264 && swfobject.getFlashPlayerVersion() || window.location.hash.indexOf("flash-test") !== -1){
-          video.children('source[src$=mp4]').first().map(i, function(source){
+          video.children('source[src$=mp4]').first().map(function(i, source){
             var src = $(source).attr('src'),
                 id = 'video_'+Math.round(1 + Math.random()*(100000)),
                 width = video.attr('width'),

--- a/.themes/classic/source/_includes/facebook_like.html
+++ b/.themes/classic/source/_includes/facebook_like.html
@@ -1,10 +1,12 @@
 {% if site.facebook_like %}
 <div id="fb-root"></div>
-<script type="text/javascript">(function(d, s, id) {
-  var js, fjs = d.getElementsByTagName(s)[0];
-  if (d.getElementById(id)) {return;}
-  js = d.createElement(s); js.id = id; js.async = true;
-  js.src = "//connect.facebook.net/en_US/all.js#appId=212934732101925&xfbml=1";
-  fjs.parentNode.insertBefore(js, fjs);
-}(document, 'script', 'facebook-jssdk'));</script>
+<script>
+  (function(d, s, id) {
+    var js, fjs = d.getElementsByTagName(s)[0];
+    if (d.getElementById(id)) return;
+    js = d.createElement(s); js.id = id;
+    js.src = "//connect.facebook.net/en_US/all.js#xfbml=1";
+    fjs.parentNode.insertBefore(js, fjs);
+  }(document, 'script', 'facebook-jssdk'));
+</script>
 {% endif %}

--- a/.themes/classic/source/_includes/google_plus_one.html
+++ b/.themes/classic/source/_includes/google_plus_one.html
@@ -1,4 +1,4 @@
-{% if site.google_plus_one %}
+{% if site.googleplus.plus_one %}
   <script type="text/javascript">
     (function() {
       var script = document.createElement('script'); script.type = 'text/javascript'; script.async = true;

--- a/.themes/classic/source/_includes/post/sharing.html
+++ b/.themes/classic/source/_includes/post/sharing.html
@@ -1,23 +1,23 @@
 <div class="sharing">
-  {% if site.twitter_tweet_button %}
+  {% if site.twitter.tweet_button %}
     {% if site.respectfully_social %}
       <a href="http://twitter.com/share" title="Tweet this" class="twitter-share" target="_blank">Tweet</a>
     {% else %}
       {% if post.title %}
-        <a href="http://twitter.com/share" class="twitter-share-button" data-url="{{ site.url }}{{ post.url }}" data-via="{{ site.twitter_user }}" data-counturl="{{ site.url }}{{ post.url }}" >Tweet</a>
+        <a href="http://twitter.com/share" class="twitter-share-button" data-url="{{ site.url }}{{ post.url }}" data-via="{{ site.twitter.user }}" data-counturl="{{ site.url }}{{ post.url }}" >Tweet</a>
       {% else %}
-        <a href="http://twitter.com/share" class="twitter-share-button" data-url="{{ site.url }}{{ page.url }}" data-via="{{ site.twitter_user }}" data-counturl="{{ site.url }}{{ page.url }}" >Tweet</a>
+        <a href="http://twitter.com/share" class="twitter-share-button" data-url="{{ site.url }}{{ page.url }}" data-via="{{ site.twitter.user }}" data-counturl="{{ site.url }}{{ page.url }}" >Tweet</a>
       {% endif %}
     {% endif %}
   {% endif %}
-  {% if site.google_plus_one %}
+  {% if site.googleplus.plus_one %}
     {% if site.respectfully_social %}
       <a title="+1 on Google Plus" class="googleplus-share" href="https://plusone.google.com/_/+1/confirm?hl=en&url={{site.url}}{{page.url}}" target="_blank">+1</a>
     {% else %}
       {% if post.title %}
-        <div class="g-plusone" data-href="{{ site.url }}{{ post.url }}" data-size="{{ site.google_plus_one_size }}"></div>
+        <div class="g-plusone" data-href="{{ site.url }}{{ post.url }}" data-size="{{ site.googleplus.plus_one_size }}"></div>
       {% else %}
-        <div class="g-plusone" data-href="{{ site.url }}{{ page.url }}" data-size="{{ site.google_plus_one_size }}"></div>
+        <div class="g-plusone" data-href="{{ site.url }}{{ page.url }}" data-size="{{ site.googleplus.plus_one_size }}"></div>
       {% endif %}
     {% endif %}
   {% endif %}

--- a/.themes/classic/source/_includes/sidebars/sections/google_plus.html
+++ b/.themes/classic/source/_includes/sidebars/sections/google_plus.html
@@ -1,5 +1,5 @@
-{% if site.google_plus_user %}
-  <a href="https://plus.google.com/{{ site.google_plus_user }}?rel=author"{% if site.google_plus_hidden %} class="googleplus-hidden"{% endif %}>
-    <img src="https://ssl.gstatic.com/images/icons/gplus-{{ site.google_plus_image_size}}.png" alt="Google Plus icon">
+{% if site.googleplus.user %}
+  <a href="https://plus.google.com/{{ site.googleplus.user }}?rel=author"{% if site.googleplus.hidden %} class="googleplus-hidden"{% endif %}>
+    <img src="https://ssl.gstatic.com/images/icons/gplus-{{ site.googleplus.image_size}}.png" alt="Google Plus icon">
   </a>
 {% endif %}

--- a/.themes/classic/source/_includes/twitter_sharing.html
+++ b/.themes/classic/source/_includes/twitter_sharing.html
@@ -1,4 +1,4 @@
-{% if site.twitter_follow_button or site.twitter_tweet_button %}
+{% if site.twitter.follow_button or site.twitter.tweet_button %}
   <script type="text/javascript">
     (function(){
       var twitterWidgets = document.createElement('script');


### PR DESCRIPTION
This is a rebase of [PR 1201](https://github.com/imathis/octopress/pull/1201) to work against current 2.1 head.
- Fix a slew of namespacing-related issues.
- Skip spurious and wacky appId on FB integration.
- Fix a minor JS bug in `flashVideoFallback`.
