### PR TITLE
Update _syntax.scss

### DIFF
--- a/.themes/classic/sass/partials/_syntax.scss
+++ b/.themes/classic/sass/partials/_syntax.scss
@@ -165,7 +165,7 @@ p, li {
   .nf     { color: $solar-blue !important; font-weight: bold !important; }                       /* Name.Function */
   .nn     { color: $solar-yellow !important; }                                          /* Name.Namespace */
   .nt     { color: $solar-blue !important; font-weight: bold !important; }                                          /* Name.Tag */
-  .nx     { color: $solar-yellow !Important; }
+  .nx     { color: $solar-yellow !important; }
   //.bp     { color: #999999 }                                          /* Name.Builtin.Pseudo */
   //.vc     { color: #008080 }                                          /* Name.Variable.Class */
   .vg     { color: $solar-blue !important; }                                          /* Name.Variable.Global */


### PR DESCRIPTION
This !important was probably not meant to be capitalized. Browsers might eat it, but your IDE/Validator (eg. IntelliJ IDEA and co.) might not. That's my use case for this change.
