### PR TITLE
Fixed gist_tag for new gist id format

### DIFF
--- a/plugins/gist_tag.rb
+++ b/plugins/gist_tag.rb
@@ -21,7 +21,7 @@ module Jekyll
     end
 
     def render(context)
-      if parts = @text.match(/(.*) (.*)/)
+      if parts = @text.match(/([^ ]*) (.*)/)
         gist, file = parts[1].strip, parts[2].strip
         script_url = script_url_for gist, file
         code       = get_cached_gist(gist, file) || get_gist_from_web(gist, file)


### PR DESCRIPTION
Just noticed that new gist ids are not numbers anymore, now they look like a kind of hash. Thus the gist_tag didn't stopped working. Fixed it.
