### PR TITLE
sitemap.xml is not correctly generated

### DIFF
--- a/plugins/sitemap_generator.rb
+++ b/plugins/sitemap_generator.rb
@@ -79,7 +79,7 @@ module Jekyll
     end
 
     def location_on_server
-      location = "#{site.config['url']}#{@dir}#{url}"
+      location = "#{site.config['url']}#{url}"
       location.gsub(/index.html$/, "")
     end
   end


### PR DESCRIPTION
Besides blog post pages, the sitemap of other pages are not generated correctly.

See my [sitemap.xml](http://www.topbug.net/sitemap.xml) for an example:

You can see entries like

```
http://www.topbug.net/about/about/
http://www.topbug.net/archives/archives/
```

The paths are repeated twice.
