### PR TITLE
Fixed gist_tag for new gist id format

### DIFF
--- a/plugins/gist_tag.rb
+++ b/plugins/gist_tag.rb
@@ -40,7 +40,7 @@ module Jekyll
     end
 
     def render(context)
-      if parts = @markup.match(/([\d]*) (.*)/)
+      if parts = @markup.match(/([^ ]*) (.*)/)
         gist, file = parts[1].strip, parts[2].strip
 
         @options[:title]     ||= file.empty? ? "Gist: #{gist}" : file


### PR DESCRIPTION
Just noticed that new gist ids are not numbers anymore, now they look like a kind of hash. Thus the gist_tag didn't stopped working. Fixed it.
