### PR TITLE
Added a "latest.markdown" symlink to the latest post, to save typing.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -99,7 +99,9 @@ task :new_post, :title do |t, args|
   end
   raise "### You haven't set anything up yet. First run `rake install` to set up an Octopress theme." unless File.directory?(source_dir)
   mkdir_p "#{source_dir}/#{posts_dir}"
-  filename = "#{source_dir}/#{posts_dir}/#{Time.now.strftime('%Y-%m-%d')}-#{title.to_url}.#{new_post_ext}"
+  filename1 = "#{source_dir}/#{posts_dir}"
+  filename2 = "#{Time.now.strftime('%Y-%m-%d')}-#{title.to_url}.#{new_post_ext}"
+  filename = "#{filename1}/#{filename2}"
   if File.exist?(filename)
     abort("rake aborted!") if ask("#{filename} already exists. Do you want to overwrite?", ['y', 'n']) == 'n'
   end
@@ -113,6 +115,10 @@ task :new_post, :title do |t, args|
     post.puts "categories: "
     post.puts "---"
   end
+  if File.exist?("#{filename1}/latest.markdown")
+      File.delete("#{filename1}/latest.markdown")
+  end
+  File.symlink("#{filename2}", "#{filename1}/latest.markdown") 
 end
 
 # usage rake new_page[my-new-page] or rake new_page[my-new-page.html] or rake new_page (defaults to "new-page.markdown")


### PR DESCRIPTION
I've modified the new_post function so that it automatically creates a symlink to the new post called "latest.markdown". This means that instead of typing 

```
new_post[post1]
vim 2013-04-30-post1.markdown
```

you can instead type

```
new_post[post1]
vim latest.markdown
```

If you are used to using tab to autocomplete file names in bash, you will realise that all you really need to type is 

```
vim l<tab>
```

because this will be the only file starting with "l" in the directory.

This is much quicker, especially when there are multiple posts in the same year, month and day.
