### PR TITLE
Updated recent posts section to check if post titles need to be title cased.

### DIFF
--- a/.themes/classic/source/_includes/asides/recent_posts.html
+++ b/.themes/classic/source/_includes/asides/recent_posts.html
@@ -3,7 +3,7 @@
   <ul id="recent_posts">
     {% for post in site.posts limit: site.recent_posts %}
       <li class="post">
-        <a href="{{ root_url }}{{ post.url }}">{{ post.title }}</a>
+        <a href="{{ root_url }}{{ post.url }}">{% if site.titlecase %}{{ post.title | titlecase }}{% else %}{{ post.title }}{% endif %}</a>
       </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
I noticed that the post titles were different from the titles in the recent posts section. Fixed this so that post titles are consistent by using the same logic in the recent posts section as the post title.
