### PR TITLE
category_generator: Don't raise error viewing categories during preview

### DIFF
--- a/plugins/category_generator.rb
+++ b/plugins/category_generator.rb
@@ -153,6 +153,9 @@ ERR
     # Returns string
     #
     def category_links(categories)
+      if !categories
+        return ""
+      end
       categories = categories.sort!.map { |c| category_link c }
 
       case categories.length


### PR DESCRIPTION
rake preview gave me the following exception:

```
Liquid Exception: undefined method `sort!' for nil:NilClass in post
/Users/chelmertz/Sites/octopress/plugins/category_generator.rb:159:in `category_links'
/Users/chelmertz/.rvm/gems/ruby-1.9.2-p320/gems/liquid-2.3.0/lib/liquid/context.rb:58:in `invoke'
/Users/chelmertz/.rvm/gems/ruby-1.9.2-p320/gems/liquid-2.3.0/lib/liquid/variable.rb:43:in `block in render'
/Users/chelmertz/.rvm/gems/ruby-1.9.2-p320/gems/liquid-2.3.0/lib/liquid/variable.rb:38:in `each'
/Users/chelmertz/.rvm/gems/ruby-1.9.2-p320/gems/liquid-2.3.0/lib/liquid/variable.rb:38:in `inject'
[...]
```

Full trace:
https://gist.github.com/chelmertz/9bdae20e70a2400a91d3

Not sure if the change should be intercepted here or
earlier but the patch avoids throwing the exception.
The server lives on to serve more requests.
