### PR TITLE
Bugfix: Missing opening <tr> tag when generating table

### DIFF
--- a/plugins/pygments_code.rb
+++ b/plugins/pygments_code.rb
@@ -82,7 +82,7 @@ module HighlightCode
     start = options[:start] || 1
     lines = options[:linenos] || true
     marks = options[:marks] || []
-    table = "<div class='highlight'><table>"
+    table = "<div class='highlight'><table><tr>"
     table += number_lines(start, code.lines.count, marks) if lines
     table += "<td class='main #{'unnumbered' unless lines} #{lang}'><pre>"
     code.lines.each_with_index do |line,index|


### PR DESCRIPTION
Pygments syntax highlighter plugin is missing an opening <tr> tag when generating the table.
