### PR TITLE
Google remote link changed

### DIFF
--- a/.themes/classic/source/_includes/asides/googleplus.html
+++ b/.themes/classic/source/_includes/asides/googleplus.html
@@ -1,7 +1,7 @@
 {% if site.googleplus_user %}
 <section class="googleplus{% if site.googleplus_hidden %} googleplus-hidden{% endif %}">
   <h1>
-    <a href="https://plus.google.com/{{ site.googleplus_user }}?rel=author">
+    <a href="https://profiles.google.com/{{ site.googleplus_user }}?rel=author">
       <img src="http://www.google.com/images/icons/ui/gprofile_button-32.png" width="32" height="32">
       Google+
     </a>


### PR DESCRIPTION
when using username for google plus, the link should be to profiles.google.com (which will redirect to plus.google.com/id)
