### PR TITLE
image_tag plugin: automatically set proper image size for retina @2x images

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ group :development do
   gem 'rb-fsevent', '~> 0.9'
   gem 'stringex', '~> 1.4.0'
   gem 'liquid', '~> 2.3.0'
+  # to get image size in image_tag plugin
+  gem 'fastimage', '~> 1.4.0'
 end
 
 gem 'sinatra', '~> 1.4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
       sass (~> 3.1)
     directory_watcher (1.4.1)
     fast-stemmer (1.0.1)
+    fastimage (1.4.0)
     fssm (0.2.9)
     haml (3.1.7)
     jekyll (0.12.0)
@@ -53,6 +54,7 @@ PLATFORMS
 DEPENDENCIES
   RedCloth (~> 4.2.9)
   compass (~> 0.12.2)
+  fastimage (~> 1.4.0)
   haml (~> 3.1.7)
   jekyll (~> 0.12)
   liquid (~> 2.3.0)


### PR DESCRIPTION
If src is defined, and the filename has the '@2x' suffix, and if the
size is not specified, get image's dimensions and set width and height
half that size. This behavior is like on iOS.
