### PR TITLE
Add config option to hide certain repos from the GitHub aside

### DIFF
--- a/.themes/classic/source/_includes/asides/github.html
+++ b/.themes/classic/source/_includes/asides/github.html
@@ -21,6 +21,7 @@
             user: '{{site.github_user}}',
             count: {{site.github_repo_count}},
             skip_forks: {{site.github_skip_forks}},
+            skip_repos: [ {% for repo in site.github_skip_repos %}"{{repo}}"{% unless forloop.last %}, {% endunless %}{% endfor %} ],
             target: '#gh_repos'
         });
     });

--- a/.themes/classic/source/javascripts/github.js
+++ b/.themes/classic/source/javascripts/github.js
@@ -21,6 +21,7 @@ var github = (function(){
           if (!data || !data.data) { return; }
           for (var i = 0; i < data.data.length; i++) {
             if (options.skip_forks && data.data[i].fork) { continue; }
+            if ( jQuery.inArray( data.data[i].name, options.skip_repos ) != -1) { continue; }
             repos.push(data.data[i]);
           }
           if (options.count) { repos.splice(options.count); }

--- a/_config.yml
+++ b/_config.yml
@@ -67,6 +67,7 @@ github_user:
 github_repo_count: 0
 github_show_profile_link: true
 github_skip_forks: true
+github_skip_repos: []  # list of repos to hide from the sidebar. ex: [blog, username.github.io, old_embarrassing_project]
 
 # Twitter
 twitter_user:


### PR DESCRIPTION
A slight modification I'm using on my site.  This is especially useful when hosting Octopress on GitHub Pages, since the repo that contains the blog source is almost guaranteed to be (a) active and (b) not especially interesting.

Note: It currently assumes the presence of jQuery.  The alternative is to add a custom array search function, since IE isn't guaranteed to have indexOf.
