### PR TITLE
Issue of not showing Gists 

### DIFF
--- a/plugins/gist_tag.rb
+++ b/plugins/gist_tag.rb
@@ -21,7 +21,7 @@ module Jekyll
     end
 
     def render(context)
-      if parts = @text.match(/([\d]*) (.*)/)
+      if parts = @text.match(/([\w]*) (.*)/)
         gist, file = parts[1].strip, parts[2].strip
         script_url = script_url_for gist, file
         code       = get_cached_gist(gist, file) || get_gist_from_web(gist, file)


### PR DESCRIPTION
Gists having ids of - 62f3d49d1fe40a11b4c7 was not showing due to using regex - d rather than w. 
You can check it out with 'w' - http://rubular.com/r/xUpEGDH6RR

And original code 'd' - http://rubular.com/r/4FoK52wgmw
