### PR TITLE
Fix .flash-video style for fluid YouTube embeds

### DIFF
--- a/.themes/classic/sass/partials/_blog.scss
+++ b/.themes/classic/sass/partials/_blog.scss
@@ -50,20 +50,18 @@ article {
   video, .flash-video { margin: 0 auto 1.5em; }
   video { display: block; width: 100%; }
   .flash-video {
-    > div {
-      position: relative;
-      display: block;
-      padding-bottom: 56.25%;
-      padding-top: 1px;
-      height: 0;
-      overflow: hidden;
-      iframe, object, embed {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-      }
+    position: relative;
+    display: block;
+    padding-bottom: 56.25%;
+    padding-top: 1px;
+    height: 0;
+    overflow: hidden;
+    iframe, object, embed {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
     }
   }
   > footer {


### PR DESCRIPTION
For fluid embeds, the CSS rules of the container of an `iframe` should be in `.flash-video` itself, not in an immediate `div` child.

The following code displays a fluid-width video:

```
<iframe src="http://www.youtube.com/embed/HW0v-NuudQw"></iframe>
```
