### PR TITLE
fix: category / category_feed failed to render post content correctly

### DIFF
--- a/.themes/classic/source/_layouts/category_feed.xml
+++ b/.themes/classic/source/_layouts/category_feed.xml
@@ -18,7 +18,7 @@ layout: nil
   {% for post in site.categories[page.category] limit: 5 %}
     <entry>
       {% include feed_entry.xml %}
-      <content type="html"><![CDATA[{{ content | markdownify | cdata_escape }}]]></content>
+      <content type="html"><![CDATA[{{ content | cdata_escape }}]]></content>
     </entry>
   {% endfor %}
 </feed>

--- a/lib/octopress/generators/category_generator.rb
+++ b/lib/octopress/generators/category_generator.rb
@@ -90,17 +90,11 @@ module Jekyll
     #  +category+     is the category currently being processed.
     def write_category_index(category_dir, category, title)
       index = CategoryIndex.new(self, self.source, category_dir, category, title)
-      index.render(self.layouts, site_payload)
-      index.write(self.dest)
-      # Record the fact that this page has been added, otherwise Site::cleanup will remove it.
       self.pages << index
 
       # Create an Atom-feed for each index.
       if self.config['category_feeds']
         feed = CategoryFeed.new(self, self.source, category_dir, category, title)
-        feed.render(self.layouts, site_payload)
-        feed.write(self.dest)
-        # Record the fact that this page has been added, otherwise Site::cleanup will remove it.
         self.pages << feed
       end
     end


### PR DESCRIPTION
https://github.com/imathis/octopress/pull/201#discussion_r154886

jekyll render and write all pages together. the explicit call of `render` and `write` is too early (posts are not rendered at that time) and redundant
