### PR TITLE
add https protocol supporting during rake setup_github_pages

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -305,9 +305,15 @@ task :setup_github_pages, :repo do |t, args|
   else
     puts "Enter the read/write url for your repository"
     puts "(For example, 'git@github.com:your_username/your_username.github.io)"
+    puts "           or 'https://github.com/your_username/your_username.github.io')"
     repo_url = get_stdin("Repository url: ")
   end
-  user = repo_url.match(/:([^\/]+)/)[1]
+  protocol = (repo_url.match(/(^git)@/).nil?) ? 'https' : 'git'
+  if protocol == 'git'
+    user = repo_url.match(/:([^\/]+)/)[1]
+  else
+    user = repo_url.match(/github\.com\/([^\/]+)/)[1]
+  end
   branch = (repo_url.match(/\/[\w-]+\.github\.(?:io|com)/).nil?) ? 'gh-pages' : 'master'
   project = (branch == 'gh-pages') ? repo_url.match(/\/([^\.]+)/)[1] : ''
   unless (`git remote -v` =~ /origin.+?octopress(?:\.git)?/).nil?


### PR DESCRIPTION
During execute "rake setup_github_pages", there is only git@github.com:username/username.github.io options, it default supports the "git" protocol.

But in some cases, there user network environment cannot support the git or SSH protocol, only https is available. So add another option of https for the "rake setup_github_pages"
