### PR TITLE
removed duplicate nested ul, ol bottom margin resets

### DIFF
--- a/.themes/classic/sass/base/_typography.scss
+++ b/.themes/classic/sass/base/_typography.scss
@@ -66,12 +66,12 @@ h6, section h5, section section h4, section section section h3 {
 p, article blockquote, ul, ol { margin-bottom: 1.5em; }
 
 ul { list-style-type: disc;
-  ul { list-style-type: circle; margin-bottom: 0px;
-    ul { list-style-type: square; margin-bottom: 0px; }}}
+  ul { list-style-type: circle;
+    ul { list-style-type: square; }}}
 
 ol { list-style-type: decimal;
-  ol { list-style-type: lower-alpha; margin-bottom: 0px;
-    ol { list-style-type: lower-roman; margin-bottom: 0px; }}}
+  ol { list-style-type: lower-alpha;
+    ol { list-style-type: lower-roman; }}}
 
 ul, ol { &, ul, ol { margin-left: 1.3em; }}
 ul, ol { ul, ol { margin-bottom: 0em; }}


### PR DESCRIPTION
`margin-bottom` was reset in nested rules like `ul { ul { ul { ... } } }`.

This though isn't necessary with the more general rule
`ul, ol { ul, ol { margin-bottom: 0em; }}`
