### PR TITLE
Don't minify CSS in development mode

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -15,4 +15,4 @@ images_dir = "source/images"
 fonts_dir = "source/fonts"
 
 line_comments = false
-output_style = :compressed
+output_style = (ENV['env'] == 'development') ? :expanded : :compressed


### PR DESCRIPTION
For ease of debugging, this gives the option to turn off minifying CSS.

To generate expanded CSS, prepend the `rake` command with `env=development`. Examples:

```
env=development rake generate
env=development rake preview
env=development rake deploy
```

Note that the first time doing this, you may need to run `rake clean` to force an overwrite of previously minified files in `public/stylesheets`.
