### PR TITLE
Add Google Plus as a comments widget in classic theme

### DIFF
--- a/.themes/classic/source/_includes/post/googleplus_thread.html
+++ b/.themes/classic/source/_includes/post/googleplus_thread.html
@@ -1,0 +1,14 @@
+{% comment %} Load script if Google+ comments are enabled and `page.comments` is either empty (index) or set to true {% endcomment %}
+{% if site.googleplus_comments_hidden != true and page.comments != false %}
+<div id="comments"></div>
+<script src="https://apis.google.com/js/plusone.js">
+</script>
+<script>
+gapi.comments.render('comments', {
+    href: '{{ site.url }}{{ page.url }}',
+    width: '624',
+    first_party_property: 'BLOGGER',
+    view_type: 'FILTERED_POSTMOD'
+});
+</script>
+{% endif %}

--- a/.themes/classic/source/_layouts/post.html
+++ b/.themes/classic/source/_layouts/post.html
@@ -25,6 +25,12 @@ single: true
     </p>
   </footer>
 </article>
+{% if site.googleplus_comments_hidden != true and page.comments == true %}
+  <section>
+    <h1>Comments</h1>
+    <div id="googleplus_thread" aria-live="polite">{% include post/googleplus_thread.html %}</div>
+  </section>
+{% endif %}
 {% if site.disqus_short_name and page.comments == true %}
   <section>
     <h1>Comments</h1>

--- a/_config.yml
+++ b/_config.yml
@@ -81,6 +81,9 @@ google_plus_one_size: medium
 googleplus_user:
 googleplus_hidden: false
 
+# Google Plus Comments
+googleplus_comments_hidden: true
+
 # Pinboard
 pinboard_user:
 pinboard_count: 3


### PR DESCRIPTION
Adds the ability to use Google+ for comments. I know a lot of the way this works is probably changing in 3.0, but I'm not sure what the state of Octopress development is right now so I figured I'd start pushing back some of the changes I wrote for my own site, then updating them to work in 3.0 if necessary.

A preview can be found (temporarily) on my blog. Eg. https://blog.samwhited.com/2013/06/new-ssl-certificates/
I may or may not retain the feature, so if it's gone just ask and I'll put it back. This probably won't work in preview-mode because Google will try to check the window location to load comments.
