### PR TITLE
Fix search support for DDG and other search engines

### DIFF
--- a/.themes/classic/source/_includes/navigation.html
+++ b/.themes/classic/source/_includes/navigation.html
@@ -7,6 +7,7 @@
   {% if site.simple_search %}
 <form action="{{ site.simple_search }}" method="get">
   <fieldset role="search">
+    <input type="hidden" name="sites" value="{{ site.url | shorthand_url }}" />
     <input type="hidden" name="q" value="site:{{ site.url | shorthand_url }}" />
     <input class="search" type="text" name="q" results="0" placeholder="Search"/>
   </fieldset>


### PR DESCRIPTION
Fix support for DuckDuckGo and other search engines in the classic theme. Probably a good patch to add before 3.0 comes out, as I've seen a lot of blogs that don't seem to realize there's a problem (when you search with them they show results for all sites).

Still works fine with Google and other sites that don't support the sites attribute.