### PR TITLE
Use HTTPS for Rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 group :development do
   gem 'rake', '~> 0.9'


### PR DESCRIPTION
It is now recommended to use HTTPS for connecting to Rubygems.
