### PR TITLE
Conform to hAtom by specifying updated time of entries

### DIFF
--- a/.themes/classic/source/_includes/archive_post.html
+++ b/.themes/classic/source/_includes/archive_post.html
@@ -1,6 +1,6 @@
 {% capture category %}{{ post.categories | size }}{% endcapture %}
 <h1><a href="{{ root_url }}{{ post.url }}">{{post.title}}</a></h1>
-<time datetime="{{ post.date | datetime | date_to_xmlschema }}" pubdate>{{ post.date | date: "<span class='month'>%b</span> <span class='day'>%d</span> <span class='year'>%Y</span>"}}</time>
+<time datetime="{{ post.date | datetime | date_to_xmlschema }}">{{ post.date | date: "<span class='month'>%b</span> <span class='day'>%d</span> <span class='year'>%Y</span>"}}</time>
 {% if category != '0' %}
 <footer>
   <span class="categories">posted in {{ post.categories | category_links }}</span>

--- a/.themes/classic/source/_includes/post/date.html
+++ b/.themes/classic/source/_includes/post/date.html
@@ -7,7 +7,7 @@
 {% capture was_updated %}{{ updated | size }}{% endcapture %}
 
 {% if has_date != '0' %}
-  {% capture time %}<time datetime="{{ date | datetime | date_to_xmlschema }}" pubdate{% if updated %} data-updated="true"{% endif %}>{{ date_formatted }}</time>{% endcapture %}
+  {% capture time %}<time datetime="{{ date | datetime | date_to_xmlschema }}" {% if was_updated == '0' %} class="updated" {% endif %}>{{ date_formatted }}</time>{% endcapture %}
 {% endif %}
 
 {% if was_updated != '0' %}


### PR DESCRIPTION
I was using [Google's structured data testing tool](http://www.google.com/webmasters/tools/richsnippets) and noticed this error:

![missing_updated](https://f.cloud.github.com/assets/478311/766321/63798d58-e85c-11e2-83b3-963b30c9febe.png)

Turns out the [hAtom Entry Updated element](http://microformats.org/wiki/hatom#Entry_Updated) is required but wasn't always being included.

The existing conditional was incorrect, so `data-updated="true"` was always being included. That data attribute doesn't seem to be used, and since it wasn't being included accurately anyways I replaced it with the `class="updated"` required by hAtom.

I also removed the `pubdate` attribute from the two places it existed since [it was dropped from HTML 5](http://www.w3.org/wiki/User:Tantekelik/drop_pubdate).

After deploying these changes, I no longer see that error from Google's structured data testing tool.
