### PR TITLE
Rake 0.9.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     RedCloth (4.2.9)
     chunky_png (1.2.5)
@@ -31,7 +31,7 @@ GEM
     rack (1.5.2)
     rack-protection (1.5.0)
       rack
-    rake (0.9.2.2)
+    rake (0.9.6)
     rb-fsevent (0.9.1)
     rdiscount (2.0.7.3)
     rubypants (0.2.0)


### PR DESCRIPTION
Hi, I was unable to install Octopress on 64-bit Arch Linux without changing the rake version in Gemfile.lock.
