### PR TITLE
Added option to deploy blog locally via rsync

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,7 @@ require "stringex"
 ssh_user       = "user@domain.com"
 ssh_port       = "22"
 document_root  = "~/website.com/"
+rsync_local    = false
 rsync_delete   = false
 rsync_args     = ""  # Any extra arguments to pass to rsync
 deploy_default = "rsync"
@@ -240,8 +241,13 @@ task :rsync do
   if File.exists?('./rsync-exclude')
     exclude = "--exclude-from '#{File.expand_path('./rsync-exclude')}'"
   end
-  puts "## Deploying website via Rsync"
-  ok_failed system("rsync -avze 'ssh -p #{ssh_port}' #{exclude} #{rsync_args} #{"--delete" unless rsync_delete == false} #{public_dir}/ #{ssh_user}:#{document_root}")
+  if rsync_local 
+    puts "## Deploying website via Rsync (locally)"
+    ok_failed system("rsync -avz #{exclude} #{rsync_args} #{"--delete" unless rsync_delete == false} #{public_dir}/ #{document_root}")
+  else
+    puts "## Deploying website via Rsync"
+    ok_failed system("rsync -avze 'ssh -p #{ssh_port}' #{exclude} #{rsync_args} #{"--delete" unless rsync_delete == false} #{public_dir}/ #{ssh_user}:#{document_root}")
+  end
 end
 
 desc "deploy public directory to github pages"


### PR DESCRIPTION
I couldn't get the current rsync-rule to work locally on my box so created a simple option to deploy the blog locally. I do not know if many will need this feature, but I often work directly on my VPS and found it quite useful. SSH-ing onto the same box you are on is not sexy :)

To push locally, just set `rsync_local` to `true`. It will be copied to `document_root` and function just as the default behavior. 
