### PR TITLE
Fix http generated images path when using Compass sprites 

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -6,6 +6,7 @@ project_type = :stand_alone
 # Publishing paths
 http_path = "/"
 http_images_path = "/images"
+http_generated_images_path = "/images"
 http_fonts_path = "/fonts"
 css_dir = "public/stylesheets"
 


### PR DESCRIPTION
Otherwise compass uses `/source/images` for the sprite image URL
