### PR TITLE
Fix update styles rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -184,7 +184,7 @@ task :update_style, :theme do |t, args|
   mv "sass", "sass.old"
   puts "## Moved styles into sass.old/"
   cp_r "#{themes_dir}/"+theme+"/sass/", "sass"
-  cp_r "sass.old/custom/.", "sass/custom"
+  cp_r "sass/custom", "sass.old/custom/."
   puts "## Updated Sass ##"
 end
 


### PR DESCRIPTION
I swapped the order of the sass/custom copy command.  It was copying the old custom sass folder into the new one rather than copying the new into the old.  That makes no sense to me so I reversed it.  If this is the intended behavior please explain because I'm baffled.
