### PR TITLE
Remove redundant reset-html5 call

### DIFF
--- a/.themes/classic/sass/screen.scss
+++ b/.themes/classic/sass/screen.scss
@@ -1,6 +1,5 @@
 @import "compass";
 @include global-reset;
-@include reset-html5;
 
 @import "custom/colors";
 @import "custom/fonts";


### PR DESCRIPTION
Found redundant css being called and traced it down to the fact that the global-reset mixin calls reset-html. See https://github.com/chriseppstein/compass/blob/192107cb4f17bef52fdd8c0d961fe77f3edb44c4/frameworks/compass/stylesheets/compass/reset/_utilities.scss
