### PR TITLE
Fixed typo in path to jQuery fallback

### DIFF
--- a/.themes/classic/source/_includes/head.html
+++ b/.themes/classic/source/_includes/head.html
@@ -23,7 +23,7 @@
   <link href="{{ site.subscribe_rss }}" rel="alternate" title="{{site.title}}" type="application/atom+xml">
   <script src="{{ root_url }}/javascripts/modernizr-2.0.js"></script>
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-  <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/lib/jquery.min.js"%3E%3C/script%3E'))</script>
+  <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="{{ root_url }}/javascripts/octopress.js" type="text/javascript"></script>
   {% include custom/head.html %}
   {% include google_analytics.html %}


### PR DESCRIPTION
The `libs` folder was typoed as `lib` in the jQuery fallback url. Fixed!
