### PR TITLE
disqus languages support

### DIFF
--- a/.themes/classic/source/_includes/disqus.html
+++ b/.themes/classic/source/_includes/disqus.html
@@ -2,6 +2,9 @@
 {% if site.disqus_short_name and page.comments != false %}
 <script type="text/javascript">
       var disqus_shortname = '{{ site.disqus_short_name }}';
+      var disqus_config = function () { 
+        this.language = '{{ site.disqus_language }}'';
+      };
       {% if page.comments == true %}
         {% comment %} `page.comments` can be only be set to true on pages/posts, so we embed the comments here. {% endcomment %}
         // var disqus_developer = 1;

--- a/.themes/classic/source/_includes/disqus.html
+++ b/.themes/classic/source/_includes/disqus.html
@@ -2,8 +2,8 @@
 {% if site.disqus_short_name and page.comments != false %}
 <script type="text/javascript">
       var disqus_shortname = '{{ site.disqus_short_name }}';
-      var disqus_config = function () { 
-        this.language = '{{ site.disqus_language }}'';
+      var disqus_config = function () {
+        this.language = '{{ site.disqus_language }}';
       };
       {% if page.comments == true %}
         {% comment %} `page.comments` can be only be set to true on pages/posts, so we embed the comments here. {% endcomment %}

--- a/_config.yml
+++ b/_config.yml
@@ -92,6 +92,7 @@ delicious_count: 3
 # Disqus Comments
 disqus_short_name:
 disqus_show_comment_count: false
+disqus_language: en
 
 # Google Analytics
 google_analytics_tracking_id:


### PR DESCRIPTION
Disqus offers multilingual support
http://help.disqus.com/customer/portal/articles/466249-can-disqus-be-loaded-in-different-languages-per-page-
This would help non-english speaking users to localize octopress-powered website.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/imathis/octopress/1304)

<!-- Reviewable:end -->
