### PR TITLE
codeblock plugin: start the line numbering with any value (default: 1)

### DIFF
--- a/plugins/code_block.rb
+++ b/plugins/code_block.rb
@@ -16,6 +16,16 @@
 # code snippet
 # {% endcodeblock %}
 #
+# To set the line numbering start with a particular number (default is 1), use firstline:N where N is the number to use for the first line of code. This is useful when the codeblock contains just a fragment of code.
+# {% codeblock mail.c firstline:345 https://github.com/php/php-src/blob/PHP-5.4.16/ext/standard/mail.c#L348 See the complete file on GitHub %}
+# fprintf(sendmail, "To: %s\n", to);
+# fprintf(sendmail, "Subject: %s\n", subject);
+# if (hdr != NULL) {
+#   fprintf(sendmail, "%s\n", hdr);
+# }
+# fprintf(sendmail, "\n%s\n", message);
+# {% endcodeblock %}
+#
 # Example:
 #
 # {% codeblock Got pain? painreleif.sh http://site.com/painreleief.sh Download it! %}
@@ -51,14 +61,20 @@ module Jekyll
     include TemplateWrapper
     CaptionUrlTitle = /(\S[\S\s]*)\s+(https?:\/\/\S+|\/\S+)\s*(.+)?/i
     Caption = /(\S[\S\s]*)/
+    FirstLine = /\s*firstline:(\d+)/
     def initialize(tag_name, markup, tokens)
       @title = nil
       @caption = nil
       @filetype = nil
       @highlight = true
+      @firstline = 1
       if markup =~ /\s*lang:(\S+)/i
         @filetype = $1
         markup = markup.sub(/\s*lang:(\S+)/i,'')
+      end
+      if markup =~ FirstLine
+        @firstline = $1.to_i
+        markup = markup.sub(FirstLine,'')
       end
       if markup =~ CaptionUrlTitle
         @file = $1
@@ -79,9 +95,9 @@ module Jekyll
       source = "<figure class='code'>"
       source += @caption if @caption
       if @filetype
-        source += " #{highlight(code, @filetype)}</figure>"
+        source += " #{highlight(code, @filetype, @firstline)}</figure>"
       else
-        source += "#{tableize_code(code.lstrip.rstrip.gsub(/</,'&lt;'))}</figure>"
+        source += "#{tableize_code(code.lstrip.rstrip.gsub(/</,'&lt;'), '', @firstline)}</figure>"
       end
       source = safe_wrap(source)
       source = context['pygments_prefix'] + source if context['pygments_prefix']

--- a/plugins/pygments_code.rb
+++ b/plugins/pygments_code.rb
@@ -6,13 +6,13 @@ PYGMENTS_CACHE_DIR = File.expand_path('../../.pygments-cache', __FILE__)
 FileUtils.mkdir_p(PYGMENTS_CACHE_DIR)
 
 module HighlightCode
-  def highlight(str, lang)
+  def highlight(str, lang, start)
     lang = 'ruby' if lang == 'ru'
     lang = 'objc' if lang == 'm'
     lang = 'perl' if lang == 'pl'
     lang = 'yaml' if lang == 'yml'
     str = pygments(str, lang).match(/<pre>(.+)<\/pre>/m)[1].to_s.gsub(/ *$/, '') #strip out divs <div class="highlight">
-    tableize_code(str, lang)
+    tableize_code(str, lang, start)
   end
 
   def pygments(code, lang)
@@ -33,11 +33,11 @@ module HighlightCode
     end
     highlighted_code
   end
-  def tableize_code (str, lang = '')
+  def tableize_code (str, lang = '', start = 1)
     table = '<div class="highlight"><table><tr><td class="gutter"><pre class="line-numbers">'
     code = ''
     str.lines.each_with_index do |line,index|
-      table += "<span class='line-number'>#{index+1}</span>\n"
+      table += "<span class='line-number'>#{index+start}</span>\n"
       code  += "<span class='line'>#{line}</span>"
     end
     table += "</pre></td><td class='code'><pre><code class='#{lang}'>#{code}</code></pre></td></tr></table></div>"


### PR DESCRIPTION
Starting the line numbering with a value different than 1 is useful when the codeblock contains just a fragment of a larger file.
See the screenshot:
![screen shot 2013-08-05 at 12 46 00](https://f.cloud.github.com/assets/1086598/909142/f23653a2-fdb3-11e2-803e-33fb7dc769c8.png)
