### PR TITLE
Updated the "rake list" command to print tasks with descriptions.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -389,15 +389,34 @@ def ask(message, valid_options)
 end
 
 desc "list tasks"
-task :list, :verbose do |t, args|
-  args.with_defaults(:verbose => false)
-  if not args.verbose
-    puts "Tasks: #{(Rake::Task.tasks - [Rake::Task[:list]]).join(', ')}"
-    puts "(type 'rake list[true]' for more details)"
-  else
-    puts "Tasks: " 
-    (Rake::Task.tasks - [Rake::Task[:list]]).each do |task|
-      puts "  '#{task.name}' - #{task.full_comment}"
-    end
+task :list do
+  tasks_excl_list = Rake::Task.tasks.reject { |task| task.name == "list" or task.name == "list_long" }
+
+  puts "Tasks: #{tasks_excl_list.join(', ')}"
+  puts "(type 'rake -T <task>' to show descriptions on a single task)"
+  puts "(type 'rake list_long' to show a list of all tasks with their descriptions)"
+end
+
+desc "list tasks with descriptions"
+task :list_long do 
+  tasks_excl_list = Rake::Task.tasks.reject { |task| task.name == "list" or task.name == "list_long" }
+  
+  # The longest task name
+  maxlen = tasks_excl_list.map { |task| task.name.length }.max
+  # Limit of chars to print for description
+  desc_lim = 80 
+
+  # Create pairs of left-justified, tabbed task names and truncated comments
+  tasks_to_print = tasks_excl_list.map { |task| 
+      [
+          "  '#{task.name}'".ljust(maxlen + 4), 
+          if task.full_comment.length <= desc_lim then task.full_comment else task.full_comment[0..desc_lim-4] + "..." end
+      ]
+  }
+
+  puts "Tasks: " 
+  tasks_to_print.each do |name, desc|
+    puts "#{name} - #{desc}"
   end
+  puts "(type 'rake -T <task>' to show full descriptions on a single task)"
 end


### PR DESCRIPTION
Hi!

Just wanted to suggest a feature for the `rake list` command so that it can print the tasks with descriptions as well. 

I made sure that my change retains the previous behavior of the `rake list` command. And I also needed that small hack at the top of the Rakefile for rake with versions >= 0.9.2.2 ([here's more information](http://stackoverflow.com/questions/825748/how-do-i-pass-command-line-arguments-to-a-rake-task)). 

Here's how `rake list` looks after the change:

```
Tasks: clean, copydot, deploy, gen_deploy, generate, install, integrate, isolate, new_page, new_post, preview, push, rsync, set_root_dir, setup_github_pages, update_source, update_style, watch
(type 'rake list[true]' for more details)
```

And how it looks after typing `rake list[true]`

```
Tasks: 
  'clean' - Clean out caches: .pygments-cache, .gist-cache, .sass-cache
  'copydot' - copy dot files for deployment
  'deploy' - Default deploy task
  'gen_deploy' - Generate website and deploy
  'generate' - Generate jekyll site
  'install' - Initial setup for Octopress: copies the default theme into the path of Jekyll's generator. Rake install defaults to rake install[classic] to install a different theme run rake install[some_theme_name]
  'integrate' - Move all stashed posts back into the posts directory, ready for site generation.
  'isolate' - Move all other posts than the one currently being worked on to a temporary stash location (stash) so regenerating the site happens much more quickly.
  'new_page' - Create a new page in source/(filename)/index.markdown
  'new_post' - Begin a new post in source/_posts
  'preview' - preview the site in a web browser
  'push' - deploy public directory to github pages
  'rsync' - Deploy website via rsync
  'set_root_dir' - Update configurations to support publishing to root or sub directory
  'setup_github_pages' - Set up _deploy folder and deploy branch for Github Pages deployment
  'update_source' - Move source to source.old, install source theme updates, replace source/_includes/navigation.html with source.old's navigation
  'update_style' - Move sass to sass.old, install sass theme updates, replace sass/custom with sass.old/custom
  'watch' - Watch the site and regenerate when it changes
```
