### PR TITLE
Add Code Climate badge to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,7 +16,7 @@ Check out [Octopress.org](http://octopress.org/docs) for guides and documentatio
 
 ## Contributing
 
-[![Build Status](https://travis-ci.org/imathis/octopress.png?branch=master)](https://travis-ci.org/imathis/octopress)
+[![Build Status](https://travis-ci.org/imathis/octopress.png?branch=master)](https://travis-ci.org/imathis/octopress) [![Code Climate](https://codeclimate.com/github/imathis/octopress.png)](https://codeclimate.com/github/imathis/octopress)
 
 We love to see people contributing to Octopress, whether it's a bug report, feature suggestion or a pull request. At the moment, we try to keep the core slick and lean, focusing on basic blogging needs, so some of your suggestions might not find their way into Octopress. For those ideas, we started a [list of 3rd party plug-ins](https://github.com/imathis/octopress/wiki/3rd-party-plugins), where you can link your own Octopress plug-in repositories. For the future, we're thinking about ways to easier add them them into our main releases.
 


### PR DESCRIPTION
Hello,

Someone (maybe you) added Octopress to Code Climate a few months back, and I thought you might want to know.

We actually use Octopress for our blog, so it's nice to have you represented on our site. You can find your quality metrics here:

https://codeclimate.com/github/imathis/octopress

In case you want this information to be available to contributors, this PR just adds a dynamic badge to the README (similar to Travis) that displays the code quality GPA.

If you have any questions, let me know.

I hope you find Code Climate useful.

Cheers,
Noah
