### PR TITLE
Verbose mode for `rake list` & `rake list` as the default command

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -394,3 +394,5 @@ task :list do
     puts "(use -v or --verbose for more detail)\n\n"
   end
 end
+
+task :default => [:list]


### PR DESCRIPTION
Here the verbose mode with the parameter -v.
I propose also that `rake list` is the default fonctin.
