### PR TITLE
Fixing Twitter plugin

### DIFF
--- a/.themes/classic/source/_includes/asides/twitter.html
+++ b/.themes/classic/source/_includes/asides/twitter.html
@@ -2,14 +2,9 @@
 <section>
   <h1>Latest Tweets</h1>
   <ul id="tweets">
-    <li class="loading">Status updating...</li>
+    <a class="twitter-timeline" data-dnt="true" href="https://twitter.com/{{ site.twitter_user }}"  data-widget-id="{{ site.twitter_widget_id }}"  data-link-color="#1863a1" data-tweet-limit="{{ site.twitter_tweet_count }}" data-chrome="noheader nofooter transparent noscrollbar">Tweets by @{{ site.twitter_user }}</a>
+    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
   </ul>
-  <script type="text/javascript">
-    $.domReady(function(){
-      getTwitterFeed("{{site.twitter_user}}", {{site.twitter_tweet_count}}, {{site.twitter_show_replies}});
-    });
-  </script>
-  <script src="{{ root_url }}/javascripts/twitter.js" type="text/javascript"> </script>
   {% if site.twitter_follow_button %}
     <a href="http://twitter.com/{{ site.twitter_user }}" class="twitter-follow-button" data-show-count="{{ site.twitter_show_follower_count }}">Follow @{{ site.twitter_user }}</a>
   {% else %}

--- a/_config.yml
+++ b/_config.yml
@@ -65,11 +65,10 @@ github_skip_forks: true
 
 # Twitter
 twitter_user:
-twitter_tweet_count: 4
-twitter_show_replies: false
+twitter_widget_id:
+twitter_tweet_count: 2
 twitter_follow_button: true
 twitter_show_follower_count: false
-twitter_tweet_button: true
 
 # Google +1
 google_plus_one: false


### PR DESCRIPTION
The Twitter plugin stopped working after they decided to stop supporting the API version it was using.

So, I substituted the functionality so it will use the standard Twitter timeline widget; it will require users to create the widget in their twitter settings page (https://twitter.com/settings/widgets) and copy the generated widget ID to _config.yml, but other than that the migration will be seamless.
