### PR TITLE
Update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     RedCloth (4.2.9)
     chunky_png (1.2.5)


### PR DESCRIPTION
Hey guys,

The source in the `Gemfile` is `https://rubygems.org/` with HTTPS instead of HTTP.

I just change to avoid different `Gemfile.lock` after bundle install command.
