### PR TITLE
Use the CNAME from /source when (re)generating _config.yml

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -338,7 +338,7 @@ task :setup_github_pages, :repo do |t, args|
     end
   end
   jekyll_config = IO.read('_config.yml')
-  jekyll_config.sub!(/^url:.*$/, "url: #{blog_url(user,project)}")
+  jekyll_config.sub!(/^url:.*$/, "url: #{blog_url(user, project)}")
   File.open('_config.yml', 'w') do |f|
     f.write jekyll_config
   end


### PR DESCRIPTION
If there's a source/CNAME present, would be good to use that instead of the repo name when generating the URL setting in _config.yml.
