### PR TITLE
Fixed setup_github_pages failing and not properly writing url to _config.yml

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -337,8 +337,9 @@ task :setup_github_pages, :repo do |t, args|
       end
     end
   end
+  url = blog_url(user, project)
   jekyll_config = IO.read('_config.yml')
-  jekyll_config.sub!(/^url:.*$/, "url: #{blog_url(user, project)}")
+  jekyll_config.sub!(/^url:.*$/, "url: #{url}")
   File.open('_config.yml', 'w') do |f|
     f.write jekyll_config
   end
@@ -358,7 +359,7 @@ task :setup_github_pages, :repo do |t, args|
       f.write rakefile
     end
   end
-  puts "\n---\n## Now you can deploy to #{blog_url(user, project)} with `rake deploy` ##"
+  puts "\n---\n## Now you can deploy to #{url} with `rake deploy` ##"
 end
 
 def ok_failed(condition)


### PR DESCRIPTION
This PR fixes the following bugs:
- `blog_url` wasn't returning anything, so the `url` field of `_config.yml` was being emptied.
- `blog_url` was writing the URL with uppercase letters (e.g., `http://Darkhogg.github.io`). Username is now downcased (project is not, I'm not sure if that would be required)
- Rake task `setup_github_pages` was trying to print the `url` variable, which is undefined. It now calls `blog_url` again.

I did not search through issues for all these bugs so I don't know if this would fix some open issue.
