### PR TITLE
[minor] typos in blogging documentation

### DIFF
--- a/source/docs/blogging/index.markdown
+++ b/source/docs/blogging/index.markdown
@@ -7,7 +7,7 @@ comments: false
 footer: false
 ---
 
-Octopress offers some rake tasks to create post and pages preloaded with metadata and according to Jekyll's naming conventions. It also generates a global and a category based feed for your posts (You can find them in `atom.xml` and `blog/categories/<category>/atom.xml`).
+Octopress offers some rake tasks to create posts and pages preloaded with metadata and according to Jekyll's naming conventions. It also generates a global and a category based feed for your posts (You can find them in `atom.xml` and `blog/categories/<category>/atom.xml`).
 
 ## Blog Posts
 Blog posts must be stored in the `source/_posts` directory and named according to Jekyll's naming conventions: `YYYY-MM-DD-post-title.markdown`. The name of the file will be used
@@ -48,8 +48,8 @@ categories:
 ---
 ```
 
-Here you can turn comments off and or categories to your post. If you are working on a multi-author blog, you can add `author: Your Name` to the
-metadata for proper attribution on a post. If you are working on a draft, you can add `published: false` to prevent it from being posted when you generate your blog. If you want to publish a [linklog](/docs/blogging/linklog) style post (blog entries point to external urls), simply add an external-url to your post.
+Here you can turn comments off and on, or add categories to your post. If you are working on a multi-author blog, you can add `author: Your Name` to the
+metadata for proper attribution on a post. If you are working on a draft, you can add `published: false` to prevent it from being posted when you generate your blog. If you want to publish a [linklog](/docs/blogging/linklog) style post (blog entries which point to external urls), simply add an external-url to your post.
 
 You can add a single category or multiple categories like this.
 


### PR DESCRIPTION
"post" to "posts"
"Here you can turn comments off and or categories to your post" to "Here you can turn comments off and on, or add categories to your post"
"blog entries point to external urls" to "blog entries which point to external urls"
