### PR TITLE
".git" added to sample string with SSH repository URL

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -307,7 +307,7 @@ task :setup_github_pages, :repo do |t, args|
     repo_url = args.repo
   else
     puts "Enter the read/write url for your repository"
-    puts "(For example, 'git@github.com:your_username/your_username.github.io)"
+    puts "(For example, 'git@github.com:your_username/your_username.github.io.git)"
     puts "           or 'https://github.com/your_username/your_username.github.io')"
     repo_url = get_stdin("Repository url: ")
   end


### PR DESCRIPTION
Octopress does not work with a repo URL like a "git@github.com:your_username/your_username.github.io" ("ERROR: repository not found" error appears).
It is necessary to add ".git" to the end of this line.
