### PR TITLE
Update jekyll to 1.2.0 to solve paginator problem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 group :development do
   gem 'rake', '~> 10.1'
-  gem 'jekyll', '~> 1.1.2'
+  gem 'jekyll', '~> 1.2.0'
   gem 'rdiscount', '~> 2.0.7'
   gem 'RedCloth', '~> 4.2.9'
   gem 'compass', '~> 0.12.2'


### PR DESCRIPTION
Using **jekyll 1.1.2** cause page path problem.

When you visit page 2, the old href link should be _{paginate_path}/3_ instead of _{paginate_path}/2/3_.

Update jekyll to latest stable version could solve this problem. :-)
