### PR TITLE
Fix Disqus over https.

### DIFF
--- a/.themes/classic/source/_includes/disqus.html
+++ b/.themes/classic/source/_includes/disqus.html
@@ -14,7 +14,7 @@
       {% endif %}
     (function () {
       var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-      dsq.src = 'http://' + disqus_shortname + '.disqus.com/' + disqus_script;
+      dsq.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + disqus_shortname + '.disqus.com/' + disqus_script;
       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     }());
 </script>


### PR DESCRIPTION
  Forcing http:// as protocol will make Disqus fail when server over
  https for security reasons.
