### PR TITLE
Handle Gists returning 302's

### DIFF
--- a/plugins/gist_tag.rb
+++ b/plugins/gist_tag.rb
@@ -88,6 +88,9 @@ module Jekyll
 
     def handle_gist_redirecting(data)
       redirected_url = data.header['Location']
+      if redirected_url.nil? || redirected_url.empty?
+        raise ArgumentError, "GitHub replied with a 302 but didn't provide a location in the response headers."
+      end
       get_web_content(redirected_url)
     end
 


### PR DESCRIPTION
The old gist url `https://gist.github.com/raw/#{gist}/#{file}` seems broken, they have username is url now.

So without username, it looks like we have to let github redirect (a 302 found response) us to the correct url.

Supercedes #1363.
