### PR TITLE
Use a protocol-relative url to load disqus over https or http

### DIFF
--- a/.themes/classic/source/_includes/disqus.html
+++ b/.themes/classic/source/_includes/disqus.html
@@ -14,7 +14,7 @@
       {% endif %}
     (function () {
       var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-      dsq.src = ('//') + disqus_shortname + '.disqus.com/' + disqus_script;
+      dsq.src = '//' + disqus_shortname + '.disqus.com/' + disqus_script;
       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     }());
 </script>


### PR DESCRIPTION
Use a simpler protocol-relative url to handle https or http for disqus
