### PR TITLE
Allow no last space for gist number only in gist tag

### DIFF
--- a/plugins/gist_tag.rb
+++ b/plugins/gist_tag.rb
@@ -23,12 +23,12 @@ module Jekyll
     def render(context)
       if parts = @text.match(/([a-zA-Z\d]*) (.*)/)
         gist, file = parts[1].strip, parts[2].strip
-        script_url = script_url_for gist, file
-        code       = get_cached_gist(gist, file) || get_gist_from_web(gist, file)
-        html_output_for script_url, code
       else
-        ""
+        gist, file = @text, ""
       end
+      script_url = script_url_for gist, file
+      code       = get_cached_gist(gist, file) || get_gist_from_web(gist, file)
+      html_output_for script_url, code
     end
 
     def html_output_for(script_url, code)


### PR DESCRIPTION
Currently, it is necessary to put a space after a gist number before "%" if no file name is given.

i.e.: 

```
{%gist 123456%}
```

This will be converted to "" (nothing), w/o errors.

It should be

```
{%gist 123456 %}
```

In addition, if the given arguments are not proper, I think it is better to give an error instead of putting nothing.
(With "diff" change, it just passes arguments to get_gist_from_web, and it should give an error.)
