### PR TITLE
Call overridden version of `to_liquid` and remove duplicate code in `Octopress::Date`

### DIFF
--- a/plugins/date.rb
+++ b/plugins/date.rb
@@ -45,10 +45,10 @@ module Octopress
     # Returns the date-specific liquid attributes
     def liquid_date_attributes
       date_format = self.site.config['date_format']
-      data = {}
-      data['date_formatted']    = format_date(self.data['date'], date_format)    if self.data.has_key?('date')
-      data['updated_formatted'] = format_date(self.data['updated'], date_format) if self.data.has_key?('updated')
-      data
+      date_attributes = {}
+      date_attributes['date_formatted']    = format_date(self.data['date'], date_format)    if self.data.has_key?('date')
+      date_attributes['updated_formatted'] = format_date(self.data['updated'], date_format) if self.data.has_key?('updated')
+      date_attributes
     end
 
   end


### PR DESCRIPTION
Make sure to call "overidden" method which keeps us nice and compatible
so we don't need to keep up with whatever Jekyll usually does, and make
sure to include it in our overriden method.

Add method `liquid_date_attributes`.

Cleanup the Post and Page overrides to be more similar.

Normally I split these up into smaller commits, but the changes were so intertwined that it wasn't efficient to do so. Tested and seems to run as expected on my blog.
