### PR TITLE
changed sidebar content color so that it does not all change color on hover

### DIFF
--- a/.themes/classic/sass/base/_theme.scss
+++ b/.themes/classic/sass/base/_theme.scss
@@ -36,7 +36,7 @@ $nav-border-right: lighten($nav-bg, 7) !default;
 
 /* Sidebar colors */
 $sidebar-bg: #f2f2f2 !default;
-$sidebar-link-color: $link-color !default;
+$sidebar-link-color: $text-color !default;
 $sidebar-link-color-hover: $link-color-hover !default;
 $sidebar-link-color-active: $link-color-active !default;
 $sidebar-color: change-color(mix($text-color, $sidebar-bg, 80), $hue: hue($sidebar-bg), $saturation: saturation($sidebar-bg)/2) !default;


### PR DESCRIPTION
As discussed in [this issue](https://github.com/imathis/octopress/issues/1403) - the sidebar of the default octopress theme highlights ALL contained links when you hover it.

I tracked the issue down, and it was because the sidebar contains only links - and these are displayed with your default link coloring which is only visible on hover.

This should fix it.
