### PR TITLE
Fix case-sensitive categories will override each other.

### DIFF
--- a/plugins/category_generator.rb
+++ b/plugins/category_generator.rb
@@ -139,9 +139,8 @@ ERR
     end
 
     def downcase_categories(categories)
-        downcase_categories = {}
+        downcase_categories = Hash.new(Array.new)
         categories.each do |k, v|
-          downcase_categories[k.downcase] ||= []
           downcase_categories[k.downcase] += v
         end
         downcase_categories


### PR DESCRIPTION
Let's say I have 2 categories `Git` and `git`.

For category links, they were generated by `category.to_url` so they will link to the same url `categories/git`

But in `plugins/category_generator.rb`, they were treated like different categories, so one of them will be overridden by the other. I think we should treat these as the same category. After all, they're generated to the same folder, and linked to the same url.
