### PR TITLE
Avoid nasty surprises when deploying to a server west of you.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -108,7 +108,7 @@ task :new_post, :title do |t, args|
     post.puts "---"
     post.puts "layout: post"
     post.puts "title: \"#{title.gsub(/&/,'&amp;')}\""
-    post.puts "date: #{Time.now.strftime('%Y-%m-%d %H:%M')}"
+    post.puts "date: #{Time.now.strftime('%Y-%m-%d %H:%M %z')}"
     post.puts "comments: true"
     post.puts "categories: "
     post.puts "---"


### PR DESCRIPTION
Creating a new post with the rake task now includes the time zone offset
so that when you write a post in GMT +2, then deploy it to your
production server in GMT -7, you don’t scratch your head wondering what
happened to your post.

Unfortunately, it might still happen that your file is named one day
differently than your post’s creation instant. I didn’t want to try to
fiddle with that. This seems to work well enough.
