### PR TITLE
Added json gem to Gemfile - fixes issue #1138

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ group :development do
   gem 'stringex', '~> 1.4.0'
   gem 'liquid', '~> 2.3.0'
   gem 'directory_watcher', '1.4.1'
+  gem 'json'
 end
 
 gem 'sinatra', '~> 1.4.2'


### PR DESCRIPTION
When trying to generate, I found that it was failing when requiring json.
The json gem was installed at the time, but that didn't change anything.
Adding it to the Gemfile and then running bundle install again fixed the problem for me,
as well as for the other people in issue #1138. I didn't add the other two gems that were
mentioned in issue #1138 because setting up the blog worked for me by just adding json.
