### PR TITLE
Optional exclusion of repositories in the Github widget

### DIFF
--- a/.themes/classic/source/_includes/asides/github.html
+++ b/.themes/classic/source/_includes/asides/github.html
@@ -21,7 +21,8 @@
             user: '{{site.github_user}}',
             count: {{site.github_repo_count}},
             skip_forks: {{site.github_skip_forks}},
-            target: '#gh_repos'
+            target: '#gh_repos',
+            blacklist: '{{site.github_blacklist_repos}}'
         });
     });
   </script>

--- a/.themes/classic/source/javascripts/github.js
+++ b/.themes/classic/source/javascripts/github.js
@@ -12,6 +12,8 @@ var github = (function(){
   }
   return {
     showRepos: function(options){
+      options.blacklist = options.blacklist.split(',');
+
       $.ajax({
           url: "https://api.github.com/users/"+options.user+"/repos?sort=pushed&callback=?"
         , dataType: 'jsonp'
@@ -21,6 +23,7 @@ var github = (function(){
           if (!data || !data.data) { return; }
           for (var i = 0; i < data.data.length; i++) {
             if (options.skip_forks && data.data[i].fork) { continue; }
+            if (options.blacklist instanceof Array && options.blacklist.indexOf(data.data[i].name) !== -1) { continue; }
             repos.push(data.data[i]);
           }
           if (options.count) { repos.splice(options.count); }

--- a/_config.yml
+++ b/_config.yml
@@ -67,6 +67,7 @@ github_user:
 github_repo_count: 0
 github_show_profile_link: true
 github_skip_forks: true
+github_blacklist_repos: "" # Comma-separated list of repositories you don't want to appear in the Github widget
 
 # Twitter
 twitter_user:


### PR DESCRIPTION
I don't necessarily want all of my Github repositories to appear on the sidebar (perhaps a work in progress I don't want to promote yet or the source repo a *.github.io page).

This PR will allow the user to exclude any repos from appearing in the sidebar using the `github_blacklist_repos` setting in the configuration file.

**Example:**
`github_blacklist_repos: "myblog.github.io,experimental,work-in-progress"` will exclude the three repositories with those names from appearing.

Absence of the `github_blacklist_repos` setting will indicate that nothing should be excluded, so this addition is backwards-compatible.
