### PR TITLE
Set the codepage to 65001 before generating

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,6 +27,10 @@ new_post_ext    = "markdown"  # default new post file extension when using the n
 new_page_ext    = "markdown"  # default new page file extension when using the new_page task
 server_port     = "4000"      # port for preview server eg. localhost:4000
 
+if (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
+  puts '## Set the codepage to 65001 for Windows machines'
+  `chcp 65001`
+end
 
 desc "Initial setup for Octopress: copies the default theme into the path of Jekyll's generator. Rake install defaults to rake install[classic] to install a different theme run rake install[some_theme_name]"
 task :install, :theme do |t, args|
@@ -51,10 +55,6 @@ end
 desc "Generate jekyll site"
 task :generate do
   raise "### You haven't set anything up yet. First run `rake install` to set up an Octopress theme." unless File.directory?(source_dir)
-  if (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
-    puts '## Set the codepage to 65001 for Windows machines'
-    `chcp 65001`
-  end
   puts "## Generating Site with Jekyll"
   system "compass compile --css-dir #{source_dir}/stylesheets"
   system "jekyll"


### PR DESCRIPTION
When I run `rake generate` on Windows, I get the following exception:

```
Liquid Exception: incompatible character encodings: UTF-8 and IBM437...
```

Turns out the fix is easy, I just need to set the code-page before running the generate command.

I added a check to ensure that the script is running on Windows before setting the codepage. I assume it'd be safe to just set it every time, but adding the check ensures it doesn't affect anyone other than Windows users.

Thanks!
