### PR TITLE
Add explicit disqus_identifier page setting

### DIFF
--- a/.themes/classic/source/_includes/disqus.html
+++ b/.themes/classic/source/_includes/disqus.html
@@ -5,7 +5,7 @@
       {% if page.comments == true %}
         {% comment %} `page.comments` can be only be set to true on pages/posts, so we embed the comments here. {% endcomment %}
         // var disqus_developer = 1;
-        var disqus_identifier = '{{ site.url }}{{ page.url }}';
+        var disqus_identifier = '{% if page.disqus_identifier %}{{ page.disqus_identifier}}{% else %}{{ site.url }}{{ page.url }}{% endif %}';
         var disqus_url = '{{ site.url }}{{ page.url }}';
         var disqus_script = 'embed.js';
       {% else %}


### PR DESCRIPTION
Some blog engines use a database generated identifier for the `disqus_identifier` value. This ensures that the comments are matched to the post even if you change the URL later.

For example, on my blog, on of my posts has the following:

```
var disqus_identifier = '156';
var disqus_url = 'http://haacked.com/archive/2004/02/03/the-new-digs.aspx';
```

This makes it very difficult to retain my Disqus comments when moving over to Octopress.

This PR adds a page field for explicitly setting the `disqus_identifier`. So on my blog, I can just set `disqus_identifier: 123` in the YAML front matter and it'll use that instead of the URL. Posts that don't have this page field set use the original behavior.

This also provides a potential solution for people who want to migrate to a new domain, but keep their comments.
