### PR TITLE
fixes font in gist source

### DIFF
--- a/.themes/classic/sass/partials/_syntax.scss
+++ b/.themes/classic/sass/partials/_syntax.scss
@@ -22,6 +22,10 @@
   @include border-radius(0);
 }
 
+html .gist .gist-file .gist-syntax .highlight .line-data {
+  font-size: 13px;
+}
+
 figure.code, .gist-file, pre {
   @include box-shadow(rgba(#000, .06) 0 0 10px);
   .highlight pre { @include box-shadow(none); }
@@ -213,7 +217,7 @@ pre, .highlight, .gist-highlight {
   &::-webkit-scrollbar-thumb:horizontal { background: $solar-scroll-thumb;  -webkit-border-radius: 4px; border-radius: 4px }
 }
 
-.highlight code { 
+.highlight code {
   @extend .pre-code; background: #000;
 }
 figure.code {


### PR DESCRIPTION
The `.line-numbers` for gists has `font-size: 13px;`, but the `.line-data` selector is set to 100%. This CSS update makes sure that they are the same by setting both to 13px.
