### PR TITLE
:copydot should ignore vim swap files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -229,7 +229,7 @@ end
 
 desc "copy dot files for deployment"
 task :copydot, :source, :dest do |t, args|
-  FileList["#{args.source}/**/.*"].exclude("**/.", "**/..", "**/.DS_Store", "**/._*").each do |file|
+  FileList["#{args.source}/**/.*"].exclude("**/.", "**/..", "**/.DS_Store", "**/._*", "**/.*.swp").each do |file|
     cp_r file, file.gsub(/#{args.source}/, "#{args.dest}") unless File.directory?(file)
   end
 end


### PR DESCRIPTION
Seems fairly common to want to `rake deploy` while you might still be
editing a blog post in vim (which creates hidden .swp files). If you
attempt to do so, you'll trip on OSX with the following:

  cp -r source/_posts/.2013-12-09-test.markdown.swp public/_posts/.2013-12-09-test.markdown.swp
  rake aborted!
  No such file or directory - public/_posts/.2013-12-09-test.markdown.swp

Instead, let's try to avoid copying .swp files.

See also: commit 254cdd35
