### PR TITLE
Do not remove the CNAME file when deploying

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -251,7 +251,7 @@ multitask :push do
   cd "#{deploy_dir}" do 
     system "git pull"
   end
-  (Dir["#{deploy_dir}/*"]).each { |f| rm_rf(f) }
+  (Dir["#{deploy_dir}/*"]).each { |f| rm_rf(f) unless f =~ /CNAME/}
   Rake::Task[:copydot].invoke(public_dir, deploy_dir)
   puts "\n## Copying #{public_dir} to #{deploy_dir}"
   cp_r "#{public_dir}/.", deploy_dir


### PR DESCRIPTION
When deploying to github with a custom domain, the rake deploy task would clobber the CNAME file where you put your custom domain name. This is a quick fix. Ideally there'd be a more integrated solution.
