### PR TITLE
fixed plugin 'date' after pull request #1397 from IQAndreas/cleanup-date

### DIFF
--- a/plugins/date.rb
+++ b/plugins/date.rb
@@ -46,7 +46,11 @@ module Octopress
     def liquid_date_attributes
       date_format = self.site.config['date_format']
       date_attributes = {}
-      date_attributes['date_formatted']    = self.respond_to?('date') ? format_date(self.date, date_format) : (format_date(self.data['date'], date_format) if self.data.has_key?('date'))
+      date_attributes['date_formatted'] = if self.respond_to?(:date)
+        format_date(self.date, date_format)
+      elsif self.data.has_key?('date')
+        format_date(self.data['date'], date_format)
+      end
       date_attributes['updated_formatted'] = format_date(self.data['updated'], date_format) if self.data.has_key?('updated')
       date_attributes
     end


### PR DESCRIPTION
The commit 64ba603 breaks the date display for posts that do not define the date into their YAML front-matter block.
The old code was using self.date to format the date.
You can check how it looks [before](http://axiac.ro/before-cleanup-date/) and [after](http://axiac.ro/after-cleanup-date/) commit 64ba603.

I checked into the source code of Jekyll and found out that, for posts, `self.date` is extracted from the file name of the post then it is overridden by the date specified in the YAML front-matter block, if any. The pages do not have this property.
