### PR TITLE
Fix bug in Octopress code.

### DIFF
--- a/plugins/octopress_filters.rb
+++ b/plugins/octopress_filters.rb
@@ -78,7 +78,7 @@ module OctopressLiquidFilters
   # Replaces relative urls with full urls
   def expand_urls(input, url='')
     url ||= '/'
-    input.gsub /(\s+(href|src)\s*=\s*["|']{1})(\/[^\"'>]*)/ do
+    input.gsub /(\b(href|src)\s*=\s*["|']{1})(\/[^\"'>]*)/ do
       $1+url+$3
     end
   end


### PR DESCRIPTION
This bug caused the following line in asides/github.html from being correctly
converted using variable substitution:

```
jxhr.src = '{{ root_url}}/javascripts/libs/jXHR.js';
```
