### PR TITLE
Allow version 2.0 (master) to use linenos, start and mark in code block

### DIFF
--- a/.themes/classic/sass/base/_solarized.scss
+++ b/.themes/classic/sass/base/_solarized.scss
@@ -1,11 +1,24 @@
+$solarized: light !default;
+$pre-bg: default !default;
+
 $base03:          #002b36 !default; //darkest blue
 $base02:          #073642 !default; //dark blue
 $base01:          #586e75 !default; //darkest gray
 $base00:          #657b83 !default; //dark gray
 $base0:           #839496 !default; //medium gray
 $base1:           #93a1a1 !default; //medium light gray
-$base2:           #eee8d5 !default; //cream
-$base3:           #fdf6e3 !default; //white
+// Test defaults for cream colors
+$base2:           default !default;
+$base3:           default !default;
+@if $solarized == dark {
+  @if $base2 == default { $base2: #eee8d5; } // cream
+  @if $base3 == default { $base3: #fdf6e3; } // cream white
+}
+@if $solarized == light {
+  // I prefer white and gray for the light theme
+  @if $base2 == default { $base2: #e5e5e5; } // light gray
+  @if $base3 == default { $base3: #fbfbfb; } // white
+}
 $solar-yellow:    #b58900 !default;
 $solar-orange:    #cb4b16 !default;
 $solar-red:       #dc322f !default;
@@ -15,10 +28,8 @@ $solar-blue:      #268bd2 !default;
 $solar-cyan:      #2aa198 !default;
 $solar-green:     #859900 !default;
 
-$solarized: dark !default;
-
 @if $solarized == light {
-
+  // Flipping the colors, This is the magic of Solarized.
   $_base03: $base03;
   $_base02: $base02;
   $_base01: $base01;
@@ -39,8 +50,27 @@ $solarized: dark !default;
 }
 
 /* non highlighted code colors */
-$pre-bg: $base03 !default;
+@if $pre-bg == default {
+  $pre-bg: $base03;
+} @else if $pre-bg != $base03 {
+  $base03: $pre-bg;
+  $base02: lighten($base03, 5);
+}
+
 $pre-border: darken($base02, 5) !default;
 $pre-color: $base1 !default;
 
+@if $pre-border != darken($base02, 5) {
+  $base02: lighten($pre-border, 5);
+}
+@if $pre-color != $base1 {
+  $base1: $pre-color;
+}
+
+$marker:        rgba(#00baff, .5) !default;
+$marker-bg:     rgba($marker, .03) !default;
+$marker-border: rgba($marker, .13) !default;
+$marker-border-left:   $marker !default;
+
+$code-selection-color: false !default;
 

--- a/.themes/classic/sass/base/_theme.scss
+++ b/.themes/classic/sass/base/_theme.scss
@@ -36,7 +36,7 @@ $nav-border-right: lighten($nav-bg, 7) !default;
 
 /* Sidebar colors */
 $sidebar-bg: #f2f2f2 !default;
-$sidebar-link-color: $text-color !default;
+$sidebar-link-color: $link-color !default;
 $sidebar-link-color-hover: $link-color-hover !default;
 $sidebar-link-color-active: $link-color-active !default;
 $sidebar-color: change-color(mix($text-color, $sidebar-bg, 80), $hue: hue($sidebar-bg), $saturation: saturation($sidebar-bg)/2) !default;

--- a/.themes/classic/sass/partials/_syntax.scss
+++ b/.themes/classic/sass/partials/_syntax.scss
@@ -1,102 +1,3 @@
-.highlight, html .gist .gist-file .gist-syntax .gist-highlight {
-  table td.code { width: 100%; }
-  border: 1px solid $pre-border !important;
-}
-.highlight .line-numbers, html .gist .gist-file .gist-syntax .highlight .line_numbers {
-  text-align: right;
-  font-size: 13px;
-  line-height: 1.45em;
-  @if $solarized == light {
-    background: lighten($base03, 1) $noise-bg !important;
-    border-right: 1px solid darken($base02, 2) !important;
-    @include box-shadow(lighten($base03, 2) -1px 0 inset);
-    text-shadow: lighten($base02, 2) 0 -1px;
-  } @else {
-    background: $base02 $noise-bg !important;
-    border-right: 1px solid darken($base03, 2) !important;
-    @include box-shadow(lighten($base02, 2) -1px 0 inset);
-    text-shadow: darken($base02, 10) 0 -1px;
-  }
-  span { color: $base01 !important; }
-  padding: .8em !important;
-  @include border-radius(0);
-}
-
-figure.code, .gist-file, pre {
-  @include box-shadow(rgba(#000, .06) 0 0 10px);
-  .highlight pre { @include box-shadow(none); }
-}
-
-.gist .highlight, figure.code .highlight {
-  @include selection(adjust-color($base03, $lightness: 23%, $saturation: -65%), $text-shadow: $base03 0 1px);
-}
-html .gist .gist-file {
-  margin-bottom: 1.8em;
-  position: relative;
-  border: none;
-  padding-top: image-height("code_bg.png") !important;
-  .highlight {
-    margin-bottom: 0;
-  }
-  .gist-syntax {
-    border-bottom: 0 !important;
-    background: none !important;
-    .gist-highlight {
-      background: $base03 !important;
-    }
-    .highlight pre {
-      @extend .pre-code;
-      padding: 0;
-    }
-  }
-  .gist-meta {
-   padding: .6em 0.8em;
-   border: 1px solid lighten($base02, 2) !important;
-   color: $base01;
-   font-size: .7em !important;
-   @if $solarized == light {
-     background: lighten($base03, 2) $noise-bg;
-     border: 1px solid $pre-border !important;
-     border-top: 1px solid lighten($base03, 2) !important;
-   } @else {
-     background: $base02 $noise-bg;
-   }
-   @extend .sans;
-   line-height: 1.5em;
-    a {
-      color: mix($base1, $base01) !important;
-      @include hover-link;
-      &:hover { color: $base1 !important; }
-    }
-    a[href*='#file'] {
-      position: absolute; top: 0; left:0; right:-10px;
-      color: #474747 !important;
-      @extend .code-title;
-      &:hover { color: $link-color !important; }
-    }
-    a[href*=raw]{
-      @extend .download-source;
-      top: .4em;
-    }
-  }
-}
-pre {
-  background: $pre-bg $noise-bg;
-  @include border-radius(.4em);
-  @extend .mono;
-  border: 1px solid $pre-border;
-  line-height: 1.45em;
-  font-size: 13px;
-  margin-bottom: 2.1em;
-  padding: .8em 1em;
-  color: $pre-color;
-  overflow: auto;
-}
-h3.filename {
-  @extend .code-title;
-  + pre { @include border-top-radius(0px); }
-}
-
 p, li {
   code {
     @extend .mono;
@@ -111,151 +12,224 @@ p, li {
     padding: 0 .3em;
     margin: -1px 0;
   }
-  pre code { font-size: 1em !important; background: none; border: none; }
+  pre code { font-size: 1em; background: none; border: none; }
 }
 
-.pre-code {
-  font-family: $mono !important;
+pre, figure.code table {
+  @if $code-selection-color != false {
+    @include selection($code-selection);
+  }
+}
+
+pre {
+  background: $pre-bg $noise-bg;
+  @include border-radius(.4em);
+  @extend .mono;
+  color: $pre-color;
   overflow: scroll;
   overflow-y: hidden;
-  display: block;
-  padding: .8em;
   overflow-x: auto;
+  border: 1px solid $pre-border;
+  margin-bottom: 2.1em;
+  padding: 1em .8em;
+  font-size: 13px;
   line-height: 1.45em;
-  background: $base03 $noise-bg !important;
-  color: $base1 !important;
-  span { color: $base1 !important; }
-  span { font-style: normal !important; font-weight: normal !important; }
+}
 
-  .c      { color: $base01 !important; font-style: italic !important; }                     /* Comment */
-  .cm     { color: $base01 !important; font-style: italic !important; }                     /* Comment.Multiline */
-  .cp     { color: $base01 !important; font-style: italic !important;  }                     /* Comment.Preproc */
-  .c1     { color: $base01 !important; font-style: italic !important; }                     /* Comment.Single */
-  .cs     { color: $base01 !important; font-weight: bold !important; font-style: italic !important; }   /* Comment.Special */
-  .err    { color: $solar-red !important; background: none !important; }                                            /* Error */
-  .k      { color: $solar-orange !important; }                       /* Keyword */
-  .o      { color: $base1 !important; font-weight: bold !important; }                       /* Operator */
-  .p      { color: $base1 !important; }                                             /* Operator */
-  .ow     { color: $solar-cyan !important; font-weight: bold !important; }                       /* Operator.Word */
-  .gd     { color: $base1 !important; background-color: mix($solar-red, $base03, 25%) !important; display: inline-block; }               /* Generic.Deleted */
-  .gd .x  { color: $base1 !important; background-color: mix($solar-red, $base03, 35%) !important; display: inline-block; }               /* Generic.Deleted.Specific */
-  .ge     { color: $base1 !important; font-style: italic !important; }                      /* Generic.Emph */
+figure.code {
+  @include box-shadow(rgba(#000, .06) 0 0 10px);
+  background: none;
+  padding: 0;
+  border: 0;
+  margin-bottom: 1.5em;
+  pre {
+    @include border-radius(0px);
+    @include box-shadow(none);
+    background: none;
+    color: $base1;
+    border: none;
+    padding: 0;
+    margin-bottom: 0;
+    overflow: visible;
+    font-style: normal;
+    font-weight: normal;
+  }
+  figcaption {
+    position: relative;
+    text-align: center;
+    font-size: 13px;
+    line-height: 2em;
+    font-weight: normal;
+    margin-bottom: 0;
+    @include border-top-radius(5px);
+    font-family: "Helvetica Neue", Arial, "Lucida Grande", "Lucida Sans Unicode", Lucida, sans-serif;
+    background-color: #aaaaaa;
+    @if lightness($base03) <= lightness(#555) {
+      text-shadow: #cbcccc 0 1px 0;
+      color: #555;
+      @include background-image(linear-gradient(
+        #e0e0e0, #cfcfcf 6%, #b1b1b1 90%, #aaaaaa
+      ));
+      border: 1px solid #a5a5a5 {
+        top-color: #cbcbcb;
+        bottom: 0;
+      }
+    }
+    @else if lightness($base03) > lightness(#555) {
+      text-shadow: #fff 0 1px 0;
+      color: #777;
+      @include background-image(linear-gradient(
+        #fff, #f0f0f0 6%, #e5e5e5 90%, #ddd
+      ));
+      border: 1px solid #c5c5c5 {
+        top-color: #d5d5d5;
+        bottom: 0;
+      }
+    }
+    a {
+      position: absolute; right: .8em;
+      @include hover-link;
+      color: inherit;
+      z-index: 1;
+      padding-left: 3em;
+    }
+  }
+  .marked {
+    position: relative;
+    display: block;
+    &:after {
+      content: "";
+      position: absolute;
+      background: $marker-bg;
+      left: -.8em; top: 0; bottom: 0; right: -.8em;
+      border: 0px solid $marker-border {
+        left-color: $marker-border-left;
+      }
+    }
+    &.start:after {
+      border-top-width: 1px;
+    }
+    &.end:after {
+      border-bottom-width: 1px;
+    }
+  }
+  .unnumbered, .line-numbers {
+    .marked:after { border-left-width: 2px; }
+  }
+}
+
+figure .highlight {
+  border: 1px solid $pre-border;
+  background: $base03;
+  overflow-y: hidden;
+  overflow-x: auto;
+
+  // allows line number to be read by screen readers but won't be selected when copying code
+  [data-line]:before { content: attr(data-line); }
+
+  td {
+    line-height: 1.45em;
+    font-size: 13px;
+    pre { padding: .8em; }
+  }
+
+  .main {
+    width: 100%;
+    background: $base03 $noise-bg;
+  }
+
+  .line-numbers {
+    text-align: right;
+    pre { color: $base01; }
+
+    @if lightness($base03) > lightness(#555) {
+      background: lighten($base03, 1) $noise-bg;
+      border-right: 1px solid darken($base02, 2);
+      @include box-shadow(lighten($base03, 2) -1px 0 inset);
+      text-shadow: lighten($base02, 2) 0 -1px;
+    } @else {
+      background: $base02 $noise-bg;
+      border-right: 1px solid darken($base03, 2);
+      @include box-shadow(lighten($base02, 2) -1px 0 inset);
+      text-shadow: darken($base02, 10) 0 -1px;
+    }
+  }
+
+  .c      { color: $base01; font-style: italic; }                     /* Comment */
+  .cm     { color: $base01; font-style: italic; }                     /* Comment.Multiline */
+  .cp     { color: $base01; font-style: italic;  }                     /* Comment.Preproc */
+  .c1     { color: $base01; font-style: italic; }                     /* Comment.Single */
+  .cs     { color: $base01; font-weight: bold; font-style: italic; }   /* Comment.Special */
+  .err    { color: $solar-red; background: none; }                                            /* Error */
+  .k      { color: $solar-orange; }                       /* Keyword */
+  .o      { color: $base1; font-weight: bold; }                       /* Operator */
+  .p      { color: $base1; }                                             /* Operator */
+  .ow     { color: $solar-cyan; font-weight: bold; }                       /* Operator.Word */
+  .gd     { color: $base1; background-color: mix($solar-red, $base03, 25%); display: inline-block; }               /* Generic.Deleted */
+  .gd .x  { color: $base1; background-color: mix($solar-red, $base03, 35%); display: inline-block; }               /* Generic.Deleted.Specific */
+  .ge     { color: $base1; font-style: italic; }                      /* Generic.Emph */
   //.gr     { color: #aa0000 }                                          /* Generic.Error */
-  .gh     { color: $base01 !important; }                                          /* Generic.Heading */
-  .gi     { color: $base1 !important; background-color: mix($solar-green, $base03, 20%) !important; display: inline-block; }               /* Generic.Inserted */
-  .gi .x  { color: $base1 !important; background-color: mix($solar-green, $base03, 40%) !important; display: inline-block; }               /* Generic.Inserted.Specific */
+  .gh     { color: $base01; }                                          /* Generic.Heading */
+  .gi     { color: $base1; background-color: mix($solar-green, $base03, 20%); display: inline-block; }               /* Generic.Inserted */
+  .gi .x  { color: $base1; background-color: mix($solar-green, $base03, 40%); display: inline-block; }               /* Generic.Inserted.Specific */
   //.go     { color: #888888 }                                          /* Generic.Output */
   //.gp     { color: #555555 }                                          /* Generic.Prompt */
-  .gs     { color: $base1 !important; font-weight: bold !important; }                                       /* Generic.Strong */
-  .gu     { color: $solar-violet !important; }                                          /* Generic.Subheading */
+  .gs     { color: $base1; font-weight: bold; }                                       /* Generic.Strong */
+  .gu     { color: $solar-violet; }                                          /* Generic.Subheading */
   //.gt     { color: #aa0000 }                                          /* Generic.Traceback */
-  .kc     { color: $solar-green !important; font-weight: bold !important; }                       /* Keyword.Constant */
-  .kd     { color: $solar-blue !important; }                       /* Keyword.Declaration */
-  .kp     { color: $solar-orange !important; font-weight: bold !important; }                       /* Keyword.Pseudo */
-  .kr     { color: $solar-magenta !important; font-weight: bold !important; }                       /* Keyword.Reserved */
-  .kt     { color: $solar-cyan !important; }                       /* Keyword.Type */
-  .n      { color: $solar-blue !important; }
-  .na     { color: $solar-blue !important; }                                          /* Name.Attribute */
-  .nb     { color: $solar-green !important; }                                          /* Name.Builtin */
-  .nc     { color: $solar-magenta !important;}                                                   /* Name.Class */
-  .no     { color: $solar-yellow !important; }                                          /* Name.Constant */
+  .kc     { color: $solar-green; font-weight: bold; }                       /* Keyword.Constant */
+  .kd     { color: $solar-blue; }                       /* Keyword.Declaration */
+  .kp     { color: $solar-orange; font-weight: bold; }                       /* Keyword.Pseudo */
+  .kr     { color: $solar-magenta; font-weight: bold; }                       /* Keyword.Reserved */
+  .kt     { color: $solar-cyan; }                       /* Keyword.Type */
+  .n      { color: $solar-blue; }
+  .na     { color: $solar-blue; }                                          /* Name.Attribute */
+  .nb     { color: $solar-green; }                                          /* Name.Builtin */
+  .nc     { color: $solar-magenta;}                                                   /* Name.Class */
+  .no     { color: $solar-yellow; }                                          /* Name.Constant */
   //.ni     { color: #800080 }                                          /* Name.Entity */
-  .nl     { color: $solar-green !important; }
-  .ne     { color: $solar-blue !important; font-weight: bold !important; }                       /* Name.Exception */
-  .nf     { color: $solar-blue !important; font-weight: bold !important; }                       /* Name.Function */
-  .nn     { color: $solar-yellow !important; }                                          /* Name.Namespace */
-  .nt     { color: $solar-blue !important; font-weight: bold !important; }                                          /* Name.Tag */
-  .nx     { color: $solar-yellow !Important; }
+  .nl     { color: $solar-green; }
+  .ne     { color: $solar-blue; font-weight: bold; }                       /* Name.Exception */
+  .nf     { color: $solar-blue; font-weight: bold; }                       /* Name.Function */
+  .nn     { color: $solar-yellow; }                                          /* Name.Namespace */
+  .nt     { color: $solar-blue; font-weight: bold; }                                          /* Name.Tag */
+  .nx     { color: $solar-yellow !important; }
   //.bp     { color: #999999 }                                          /* Name.Builtin.Pseudo */
   //.vc     { color: #008080 }                                          /* Name.Variable.Class */
-  .vg     { color: $solar-blue !important; }                                          /* Name.Variable.Global */
-  .vi     { color: $solar-blue !important; }                                          /* Name.Variable.Instance */
-  .nv     { color: $solar-blue !important; }                                          /* Name.Variable */
+  .vg     { color: $solar-blue; }                                          /* Name.Variable.Global */
+  .vi     { color: $solar-blue; }                                          /* Name.Variable.Instance */
+  .nv     { color: $solar-blue; }                                          /* Name.Variable */
   //.w      { color: #bbbbbb }                                          /* Text.Whitespace */
-  .mf     { color: $solar-cyan !important; }                                          /* Literal.Number.Float */
-  .m      { color: $solar-cyan !important; }                                          /* Literal.Number */
-  .mh     { color: $solar-cyan !important; }                                          /* Literal.Number.Hex */
-  .mi     { color: $solar-cyan !important; }                                          /* Literal.Number.Integer */
+  .mf     { color: $solar-cyan; }                                          /* Literal.Number.Float */
+  .m      { color: $solar-cyan; }                                          /* Literal.Number */
+  .mh     { color: $solar-cyan; }                                          /* Literal.Number.Hex */
+  .mi     { color: $solar-cyan; }                                          /* Literal.Number.Integer */
   //.mo     { color: #009999 }                                          /* Literal.Number.Oct */
-  .s      { color: $solar-cyan !important; }                                             /* Literal.String */
+  .s      { color: $solar-cyan; }                                             /* Literal.String */
   //.sb     { color: #d14 }                                             /* Literal.String.Backtick */
   //.sc     { color: #d14 }                                             /* Literal.String.Char */
-  .sd     { color: $solar-cyan !important; }                                             /* Literal.String.Doc */
-  .s2     { color: $solar-cyan !important; }                                             /* Literal.String.Double */
-  .se     { color: $solar-red !important; }                                             /* Literal.String.Escape */
+  .sd     { color: $solar-cyan; }                                             /* Literal.String.Doc */
+  .s2     { color: $solar-cyan; }                                             /* Literal.String.Double */
+  .se     { color: $solar-red; }                                             /* Literal.String.Escape */
   //.sh     { color: #d14 }                                             /* Literal.String.Heredoc */
-  .si     { color: $solar-blue !important; }                                             /* Literal.String.Interpol */
+  .si     { color: $solar-blue; }                                             /* Literal.String.Interpol */
   //.sx     { color: #d14 }                                             /* Literal.String.Other */
-  .sr     { color: $solar-cyan !important; }                                          /* Literal.String.Regex */
-  .s1     { color: $solar-cyan !important; }                                             /* Literal.String.Single */
+  .sr     { color: $solar-cyan; }                                          /* Literal.String.Regex */
+  .s1     { color: $solar-cyan; }                                             /* Literal.String.Single */
   //.ss     { color: #990073 }                                          /* Literal.String.Symbol */
   //.il     { color: #009999 }                                          /* Literal.Number.Integer.Long */
   div { .gd, .gd .x, .gi, .gi .x { display: inline-block; width: 100%; }}
 }
 
-.highlight, .gist-highlight {
-  pre { background: none; @include border-radius(0px); border: none; padding: 0; margin-bottom: 0; }
-  margin-bottom: 1.8em;
-  background: $base03;
-  overflow-y: hidden;
-  overflow-x: auto;
-}
-
 $solar-scroll-bg: rgba(#fff, .15);
 $solar-scroll-thumb: rgba(#fff, .2);
-@if $solarized == light {
+@if lightness($base03) > lightness(#555) {
   $solar-scroll-bg: rgba(#000, .15);
   $solar-scroll-thumb: rgba(#000, .15);
 }
 
-pre, .highlight, .gist-highlight {
+pre, figure .highlight {
   &::-webkit-scrollbar {  height: .5em; background: $solar-scroll-bg; }
   &::-webkit-scrollbar-thumb:horizontal { background: $solar-scroll-thumb;  -webkit-border-radius: 4px; border-radius: 4px }
 }
 
-.highlight code { 
-  @extend .pre-code; background: #000;
-}
-figure.code {
-  background: none;
-  padding: 0;
-  border: 0;
-  margin-bottom: 1.5em;
-  pre { margin-bottom: 0; }
-  figcaption {
-    position: relative;
-    @extend .code-title;
-    a { @extend .download-source; }
-  }
-  .highlight {
-    margin-bottom: 0;
-  }
-}
-
-.code-title {
-  text-align: center;
-  font-size: 13px;
-  line-height: 2em;
-  text-shadow: #cbcccc 0 1px 0;
-  color: #474747;
-  font-weight: normal;
-  margin-bottom: 0;
-  @include border-top-radius(5px);
-  font-family: "Helvetica Neue", Arial, "Lucida Grande", "Lucida Sans Unicode", Lucida, sans-serif;
-  background: #aaaaaa image-url("code_bg.png") top repeat-x;
-  border: 1px solid #565656;
-  border-top-color: #cbcbcb;
-  border-left-color: #a5a5a5;
-  border-right-color: #a5a5a5;
-  border-bottom: 0;
-}
-
-.download-source {
-  position: absolute; right: .8em;
-  @include hover-link;
-  color: #666 !important;
-  z-index: 1;
-  font-size: 13px;
-  text-shadow: #cbcccc 0 1px 0;
-  padding-left: 3em;
-}

--- a/.themes/classic/sass/screen.scss
+++ b/.themes/classic/sass/screen.scss
@@ -1,5 +1,6 @@
 @import "compass";
 @include global-reset;
+@include reset-html5;
 
 @import "custom/colors";
 @import "custom/fonts";

--- a/.themes/classic/source/_includes/archive_post.html
+++ b/.themes/classic/source/_includes/archive_post.html
@@ -1,5 +1,5 @@
 {% capture category %}{{ post.categories | size }}{% endcapture %}
-<h1><a href="{{ root_url }}{{ post.url }}">{% if site.titlecase %}{{ post.title | titlecase }}{% else %}{{ post.title }}{% endif %}</a></h1>
+<h1><a href="{{ root_url }}{{ post.url }}">{{post.title}}</a></h1>
 <time datetime="{{ post.date | datetime | date_to_xmlschema }}" pubdate>{{ post.date | date: "<span class='month'>%b</span> <span class='day'>%d</span> <span class='year'>%Y</span>"}}</time>
 {% if category != '0' %}
 <footer>

--- a/.themes/classic/source/_includes/article.html
+++ b/.themes/classic/source/_includes/article.html
@@ -9,8 +9,7 @@
       <p class="meta">
         {% include post/date.html %}{{ time }}
         {% if site.disqus_short_name and page.comments != false and post.comments != false and site.disqus_show_comment_count == true %}
-           | <a href="{% if index %}{{ root_url }}{{ post.url }}{% endif %}#disqus_thread"
-             data-disqus-identifier="{% if post.meta.disqus_id %}{{ post.meta.disqus_id }}{% else %}{{ site.url }}{{ post.url }}{% endif %}">Comments</a>
+         | <a href="{% if index %}{{ root_url }}{{ post.url }}{% endif %}#disqus_thread">Comments</a>
         {% endif %}
       </p>
     {% endunless %}

--- a/.themes/classic/source/_includes/custom/category_feed.xml
+++ b/.themes/classic/source/_includes/custom/category_feed.xml
@@ -4,7 +4,7 @@ layout: nil
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
 
-  <title><![CDATA[{% if site.titlecase %}{{ page.title | titlecase | cdata_escape }}{% else %}{{ page.title | cdata_escape }}{% endif %} | {{ site.title | cdata_escape }}]]></title>
+  <title><![CDATA[{{ page.title }} | {{ site.title }}]]></title>
   <link href="{{ site.url }}/{{ page.feed_url }}" rel="self"/>
   <link href="{{ site.url }}/"/>
   <updated>{{ site.time | date_to_xmlschema }}</updated>
@@ -17,7 +17,7 @@ layout: nil
 
   {% for post in site.categories[page.category] limit: 5 %}
   <entry>
-    <title type="html"><![CDATA[{% if site.titlecase %}{{ post.title | titlecase | cdata_escape }}{% else %}{{ post.title | cdata_escape }}{% endif %}]]></title>
+    <title type="html"><![CDATA[{{ post.title | cdata_escape }}]]></title>
     <link href="{{ site.url }}{{ post.url }}"/>
     <updated>{{ post.date | date_to_xmlschema }}</updated>
     <id>{{ site.url }}{{ post.id }}</id>

--- a/.themes/classic/source/_includes/disqus.html
+++ b/.themes/classic/source/_includes/disqus.html
@@ -14,7 +14,7 @@
       {% endif %}
     (function () {
       var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-      dsq.src = '//' + disqus_shortname + '.disqus.com/' + disqus_script;
+      dsq.src = 'http://' + disqus_shortname + '.disqus.com/' + disqus_script;
       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     }());
 </script>

--- a/.themes/classic/source/_includes/head.html
+++ b/.themes/classic/source/_includes/head.html
@@ -4,7 +4,7 @@
 <!--[if (gt IE 8)|(gt IEMobile 7)|!(IEMobile)|!(IE)]><!--><html class="no-js" lang="en"><!--<![endif]-->
 <head>
   <meta charset="utf-8">
-  <title>{% if page.title %}{% if site.titlecase %}{{ page.title | titlecase }}{% else %}{{ page.title }}{% endif %} - {% endif %}{{ site.title }}</title>
+  <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
   <meta name="author" content="{{ site.author }}">
 
   {% capture description %}{% if page.description %}{{ page.description }}{% else %}{{ content | raw_content }}{% endif %}{% endcapture %}
@@ -23,7 +23,7 @@
   <link href="{{ site.subscribe_rss }}" rel="alternate" title="{{site.title}}" type="application/atom+xml">
   <script src="{{ root_url }}/javascripts/modernizr-2.0.js"></script>
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-  <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
+  <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/lib/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="{{ root_url }}/javascripts/octopress.js" type="text/javascript"></script>
   {% include custom/head.html %}
   {% include google_analytics.html %}

--- a/.themes/classic/source/atom.xml
+++ b/.themes/classic/source/atom.xml
@@ -4,7 +4,7 @@ layout: nil
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
 
-  <title><![CDATA[{{ site.title | cdata_escape }}]]></title>
+  <title><![CDATA[{{ site.title }}]]></title>
   <link href="{{ site.url }}/atom.xml" rel="self"/>
   <link href="{{ site.url }}/"/>
   <updated>{{ site.time | date_to_xmlschema }}</updated>
@@ -17,7 +17,7 @@ layout: nil
 
   {% for post in site.posts limit: 20 %}
   <entry>
-    <title type="html"><![CDATA[{% if site.titlecase %}{{ post.title | titlecase | cdata_escape }}{% else %}{{ post.title | cdata_escape }}{% endif %}]]></title>
+    <title type="html"><![CDATA[{{ post.title | cdata_escape }}]]></title>
     <link href="{{ site.url }}{{ post.url }}"/>
     <updated>{{ post.date | date_to_xmlschema }}</updated>
     <id>{{ site.url }}{{ post.id }}</id>

--- a/.themes/classic/source/index.html
+++ b/.themes/classic/source/index.html
@@ -12,11 +12,11 @@ layout: default
   {% endfor %}
   <div class="pagination">
     {% if paginator.next_page %}
-      <a class="prev" href="{{paginator.next_page}}">&larr; Older</a>
+      <a class="prev" href="{{paginator.next_page_path}}">&larr; Older</a>
     {% endif %}
     <a href="/blog/archives">Blog Archives</a>
     {% if paginator.previous_page %}
-    <a class="next" href="{{paginator.previous_page}}">Newer &rarr;</a>
+    <a class="next" href="{{paginator.previous_page_path}}">Newer &rarr;</a>
     {% endif %}
   </div>
 </div>

--- a/plugins/code_block.rb
+++ b/plugins/code_block.rb
@@ -42,51 +42,47 @@
 # </figure>
 #
 require './plugins/pygments_code'
-require './plugins/raw'
 
 module Jekyll
 
   class CodeBlock < Liquid::Block
-    include HighlightCode
-    include TemplateWrapper
-    CaptionUrlTitle = /(\S[\S\s]*)\s+(https?:\/\/\S+|\/\S+)\s*(.+)?/i
-    Caption = /(\S[\S\s]*)/
+    TitleUrlLinkText = /(\S[\S\s]*)\s+(https?:\/\/\S+|\/\S+)\s*(.+)?/i
+    Title = /(\S[\S\s]*)/
     def initialize(tag_name, markup, tokens)
-      @title = nil
-      @caption = nil
-      @filetype = nil
-      @highlight = true
-      if markup =~ /\s*lang:(\S+)/i
-        @filetype = $1
-        markup = markup.sub(/\s*lang:(\S+)/i,'')
+
+      @markup = markup
+      clean_markup = Octopress::Pygments.clean_markup(markup)
+      if clean_markup =~ TitleUrlLinkText
+        @options = {
+          title:     $1,
+          url:       $2,
+          link_text: $3
+        }
+      elsif clean_markup =~ Title
+        @options = { title: $1 }
       end
-      if markup =~ CaptionUrlTitle
-        @file = $1
-        @caption = "<figcaption><span>#{$1}</span><a href='#{$2}'>#{$3 || 'link'}</a></figcaption>"
-      elsif markup =~ Caption
-        @file = $1
-        @caption = "<figcaption><span>#{$1}</span></figcaption>\n"
+
+      # grab lang from filename in title
+      if @options[:title] =~ /\S[\S\s]*\w+\.(\w+)/ && @options[:lang].nil?
+        @options[:lang] = $1
       end
-      if @file =~ /\S[\S\s]*\w+\.(\w+)/ && @filetype.nil?
-        @filetype = $1
-      end
+
+      @options = Octopress::Pygments.parse_markup(markup, @options)
+
       super
     end
 
     def render(context)
-      output = super
-      code = super
-      source = "<figure class='code'>"
-      source += @caption if @caption
-      if @filetype
-        source += "#{highlight(code, @filetype)}</figure>"
-      else
-        source += "#{tableize_code(code.lstrip.rstrip.gsub(/</,'&lt;'))}</figure>"
+      begin
+        code = super.strip
+        code = Octopress::Pygments.highlight(code, @options)
+        code = context['pygments_prefix'] + code if context['pygments_prefix']
+        code = code + context['pygments_suffix'] if context['pygments_suffix']
+        code
+      rescue MentosError => e
+        markup = "{% codeblock #{@markup} %}"
+        Octopress::Pygments.highlight_failed(e, "{% codeblock [lang:language] [title] [url] [link text] [start:#] [mark:#,#-#] [linenos:false] %}\ncode\n{% endcodeblock %}", markup, code)
       end
-      source = safe_wrap(source)
-      source = context['pygments_prefix'] + source if context['pygments_prefix']
-      source = source + context['pygments_suffix'] if context['pygments_suffix']
-      source
     end
   end
 end

--- a/plugins/include_code.rb
+++ b/plugins/include_code.rb
@@ -15,30 +15,36 @@
 # Example 2:
 # You can also include an optional title for the <figcaption>
 #
-# {% include_code Example 2 javascripts/test.js %}
+# {% include_code javascripts/test.js Example 2 %}
 #
 # will output a figcaption with the title: Example 2 (test.js)
 #
 
-require './plugins/pygments_code'
-require './plugins/raw'
+#require 'colorator'
 require 'pathname'
+require './plugins/pygments_code'
 
 module Jekyll
 
   class IncludeCodeTag < Liquid::Tag
-    include HighlightCode
-    include TemplateWrapper
     def initialize(tag_name, markup, tokens)
-      @title = nil
       @file = nil
-      if markup.strip =~ /\s*lang:(\S+)/i
-        @filetype = $1
-        markup = markup.strip.sub(/lang:\S+/i,'')
-      end
-      if markup.strip =~ /(.*)?(\s+|^)(\/*\S+)/i
-        @title = $1 || nil
-        @file = $3
+      @title_old = nil
+      @original_markup = markup
+
+      opts = Octopress::Pygments.parse_markup(markup)
+      @options = opts.merge({
+        link_text: opts[:link_text] || 'view raw',
+        start:     opts[:start]     || 1
+      })
+      markup = Octopress::Pygments.clean_markup(markup)
+
+      if markup.strip =~ /(^\S*\.\S+) *(.+)?/i
+        @file = $1
+        @options[:title] ||= $2
+      elsif markup.strip =~ /(.*?)(\S*\.\S+)\Z/i # Title before file is deprecated in 2.1
+        @title_old = $1
+        @file = $2
       end
       super
     end
@@ -46,28 +52,43 @@ module Jekyll
     def render(context)
       code_dir = (context.registers[:site].config['code_dir'].sub(/^\//,'') || 'downloads/code')
       code_path = (Pathname.new(context.registers[:site].source) + code_dir).expand_path
-      file = code_path + @file
+      filepath = code_path + @file
 
-      if File.symlink?(code_path)
-        return "Code directory '#{code_path}' cannot be a symlink"
+      unless @title_old.nil?
+        @options[:title] ||= @title_old
+        puts "### ------------ WARNING ------------ ###".yellow
+        puts "This include_code syntax is deprecated ".yellow
+        puts "Correct syntax: path/to/file.ext [title]".yellow
+        puts "Update include for #{filepath}".yellow
+        puts "### --------------------------------- ###".yellow
       end
 
-      unless file.file?
-        return "File #{file} could not be found"
+      if File.symlink?(code_path)
+        puts "Code directory '#{code_path}' cannot be a symlink".yellow
+        return "Code directory '#{code_path}' cannot be a symlink".yellow
+      end
+
+      unless filepath.file?
+        puts "File #{filepath} could not be found".yellow
+        return "File #{filepath} could not be found".yellow
       end
 
       Dir.chdir(code_path) do
-        code = file.read
-        @filetype = file.extname.sub('.','') if @filetype.nil?
-        title = @title ? "#{@title} (#{file.basename})" : file.basename
-        url = "/#{code_dir}/#{@file}"
-        source = "<figure class='code'><figcaption><span>#{title}</span> <a href='#{url}'>download</a></figcaption>\n"
-        source += "#{highlight(code, @filetype)}</figure>"
-        safe_wrap(source)
+        @options[:lang]  ||= filepath.extname.sub('.','')
+        @options[:title]   = @options[:title] ? "#{@options[:title]} (#{filepath.basename})" : filepath.basename
+        @options[:url]   ||= "/#{code_dir}/#{@file}"
+
+        code = filepath.read
+        code = get_range(code, @options[:start], @options[:end])
+        begin
+          Octopress::Pygments.highlight(code, @options)
+        rescue MentosError => e
+          markup = "{% include_code #{@original_markup} %}"
+          Octopress::Pygments.highlight_failed(e, "{% include_code [title] [lang:language] path/to/file [start:#] [end:#] [range:#-#] [mark:#,#-#] [linenos:false] %}", markup, code, filepath)
+        end
       end
     end
   end
-
 end
 
 Liquid::Template.register_tag('include_code', Jekyll::IncludeCodeTag)

--- a/plugins/octopress_filters.rb
+++ b/plugins/octopress_filters.rb
@@ -8,8 +8,8 @@ require 'rubypants'
 module OctopressFilters
   include BacktickCodeBlock
   include TemplateWrapper
-  def pre_filter(input)
-    input = render_code_block(input)
+  def pre_filter(input, ext)
+    input = render_code_block(input, ext)
     input.gsub /(<figure.+?>.+?<\/figure>)/m do
       safe_wrap($1)
     end
@@ -25,7 +25,7 @@ module Jekyll
     include OctopressFilters
     def pre_render(post)
       if post.ext.match('html|textile|markdown|md|haml|slim|xml')
-        post.content = pre_filter(post.content)
+        post.content = pre_filter(post.content, post.ext)
       end
     end
     def post_render(post)

--- a/plugins/pygments_code.rb
+++ b/plugins/pygments_code.rb
@@ -1,45 +1,197 @@
 require 'pygments'
 require 'fileutils'
 require 'digest/md5'
+#require 'colorator'
 
 PYGMENTS_CACHE_DIR = File.expand_path('../../.pygments-cache', __FILE__)
 FileUtils.mkdir_p(PYGMENTS_CACHE_DIR)
 
-module HighlightCode
-  def highlight(str, lang)
-    lang = 'ruby' if lang == 'ru'
-    lang = 'objc' if lang == 'm'
-    lang = 'perl' if lang == 'pl'
-    lang = 'yaml' if lang == 'yml'
-    str = pygments(str, lang).match(/<pre>(.+)<\/pre>/m)[1].to_s.gsub(/ *$/, '') #strip out divs <div class="highlight">
-    tableize_code(str, lang)
-  end
+module Octopress
+  module Pygments
 
-  def pygments(code, lang)
-    if defined?(PYGMENTS_CACHE_DIR)
-      path = File.join(PYGMENTS_CACHE_DIR, "#{lang}-#{Digest::MD5.hexdigest(code)}.html")
-      if File.exist?(path)
-        highlighted_code = File.read(path)
-      else
-        begin
-          highlighted_code = Pygments.highlight(code, :lexer => lang, :formatter => 'html', :options => {:encoding => 'utf-8', :startinline => true})
-        rescue MentosError
-          raise "Pygments can't parse unknown language: #{lang}."
-        end
-        File.open(path, 'w') {|f| f.print(highlighted_code) }
+    def self.render_pygments(code, lang)
+      highlighted_code = ::Pygments.highlight(code, :lexer => lang, :formatter => 'html', :options => {:encoding => 'utf-8'})
+      highlighted_code = highlighted_code.gsub(/{{/, '&#x7b;&#x7b;').gsub(/{%/, '&#x7b;&#x25;')
+      highlighted_code.to_s
+    end
+
+    def self.highlight(code, options = {})
+      lang = options[:lang]
+      lang = 'ruby' if lang == 'ru'
+      lang = 'objc' if lang == 'm'
+      lang = 'perl' if lang == 'pl'
+      lang = 'yaml' if lang == 'yml'
+      lang = 'coffeescript' if lang == 'coffee'
+      lang = 'csharp' if lang == 'cs'
+      lang = 'plain' if lang == '' or lang.nil? or !lang
+
+      options[:lang] = lang
+      options[:title] ||= ' ' if options[:url]
+
+      # Attempt to retrieve cached code
+      cache = nil
+      unless options[:no_cache]
+        path  = options[:cache_path] || get_cache_path(PYGMENTS_CACHE_DIR, options[:lang], options.to_s + code)
+        cache = read_cache(path)
       end
-    else
-      highlighted_code = Pygments.highlight(code, :lexer => lang, :formatter => 'html', :options => {:encoding => 'utf-8', :startinline => true})
+
+      unless cache
+       if options[:lang] == 'plain'
+          # Escape html tags
+          code = code.gsub('<','&lt;')
+        else
+          code = render_pygments(code, options[:lang]).match(/<pre>(.+)<\/pre>/m)[1].gsub(/ *$/, '') #strip out divs <div class="highlight">
+        end
+        code = tableize_code(code, options[:lang], {linenos: options[:linenos], start: options[:start], marks: options[:marks]})
+        title = captionize(options[:title], options[:url], options[:link_text]) if options[:title]
+        code = "<figure class='code'>#{title}#{code}</figure>"
+        File.open(path, 'w') {|f| f.print(code) } unless options[:no_cache]
+      end
+      cache || code
     end
-    highlighted_code
-  end
-  def tableize_code (str, lang = '')
-    table = '<div class="highlight"><table><tr><td class="gutter"><pre class="line-numbers">'
-    code = ''
-    str.lines.each_with_index do |line,index|
-      table += "<span class='line-number'>#{index+1}</span>\n"
-      code  += "<span class='line'>#{line}</span>"
+
+    def self.read_cache (path)
+      File.exist?(path) ? File.read(path) : nil unless path.nil?
     end
-    table += "</pre></td><td class='code'><pre><code class='#{lang}'>#{code}</code></pre></td></tr></table></div>"
+
+    def self.get_cache_path (dir, name, str)
+      File.join(dir, "#{name}-#{Digest::MD5.hexdigest(str)}.html")
+    end
+
+    def self.captionize (caption, url, link_text)
+      figcaption  = "<figcaption>#{caption}"
+      figcaption += "<a href='#{url}'>#{(link_text || 'link').strip}</a>" if url
+      figcaption += "</figcaption>"
+    end
+
+    def self.tableize_code (code, lang, options = {})
+      start = options[:start] || 1
+      lines = options[:linenos] || true
+      marks = options[:marks] || []
+      table = "<div class='highlight'><table><tr>"
+      table += number_lines(start, code.lines.count, marks) if lines
+      table += "<td class='main #{'unnumbered' unless lines} #{lang}'><pre>"
+      code.lines.each_with_index do |line,index|
+        classes = 'line'
+        if marks.include? index + start
+          classes += ' marked'
+          classes += ' start' unless marks.include? index - 1 + start
+          classes += ' end' unless marks.include? index + 1 + start
+        end
+        line = line.strip.empty? ? ' ' : line
+        table += "<div class='#{classes}'>#{line}</div>"
+      end
+      table +="</pre></td></tr></table></div>"
+    end
+
+    def self.number_lines (start, count, marks)
+      start ||= 1
+      lines = "<td class='line-numbers' aria-hidden='true'><pre>"
+      count.times do |index|
+        classes = 'line-number'
+        if marks.include? index + start
+          classes += ' marked'
+          classes += ' start' unless marks.include? index - 1 + start
+          classes += ' end' unless marks.include? index + 1 + start
+        end
+        lines += "<div data-line='#{index + start}' class='#{classes}'></div>"
+      end
+      lines += "</pre></td>"
+    end
+
+    def self.parse_markup (input, defaults={})
+      lang      = input.match(/\s*lang:\s*(\S+)/i)
+      lang      = (lang.nil? ? nil : lang[1])
+
+      url       = input.match(/\s*url:\s*(("(.+?)")|('(.+?)')|(\S+))/i)
+      url       = (url.nil? ? nil : url[3] || url[5] || url[6])
+
+      title     = input.match(/\s*title:\s*(("(.+?)")|('(.+?)')|(\S+))/i)
+      title     = (title.nil? ? nil : title[3] || title[5] || title[6])
+      title   ||= ' ' if url
+
+      linenos   = input.match(/\s*linenos:\s*(\w+)/i)
+      linenos   = (linenos.nil? ? nil : linenos[1])
+
+      marks     = get_marks(input)
+
+      link_text = input.match(/\s*link[-_]text:\s*(("(.+?)")|('(.+?)')|(\S+))/i)
+      link_text = (link_text.nil? ? 'link' : link_text[3] || link_text[5] || link_text[6])
+
+      start     = input.match(/\s*start:\s*(\d+)/i)
+      start     = (start.nil? ? nil : start[1].to_i)
+
+      endline   = input.match(/\s*end:\s*(\d+)/i)
+      endline   = (endline.nil? ? nil : endline[1].to_i)
+
+      if input =~ / *range:(\d+)-(\d+)/i
+        start = $1.to_i
+        endline = $2.to_i
+      end
+
+      options = {
+        lang: lang,
+        url: url,
+        title: title,
+        linenos: linenos,
+        marks: marks,
+        link_text: link_text,
+        start: start,
+        end: endline
+      }
+
+      #defaults.each { |k,v| options[k] ||= defaults[k] }
+      options.each { |k,v| options[k] ||= defaults[k] }
+    end
+
+    def self.clean_markup (input)
+      input.sub(/\s*lang:\s*\S+/i,''
+          ).sub(/\s*title:\s*(("(.+?)")|('(.+?)')|(\S+))/i,''
+          ).sub(/\s*url:\s*(\S+)/i,''
+          ).sub(/\s*link_text:\s*(("(.+?)")|('(.+?)')|(\S+))/i,''
+          ).sub(/\s*mark:\s*\d\S*/i,''
+          ).sub(/\s*linenos:\s*\w+/i,''
+          ).sub(/\s*start:\s*\d+/i,''
+          ).sub(/\s*end:\s*\d+/i,''
+          ).sub(/\s*range:\s*\d+-\d+/i,'')
+    end
+
+    def self.get_marks (input)
+      # Matches pattern for line marks and returns array of line numbers to mark
+      # Example input mark:1,5-10,2
+      # Outputs: [1,2,5,6,7,8,9,10]
+      marks = []
+      if input =~ / *mark:(\d\S*)/i
+        marks = $1.gsub /(\d+)-(\d+)/ do
+          ($1.to_i..$2.to_i).to_a.join(',')
+        end
+        marks = marks.split(',').collect {|s| s.to_i}.sort
+      end
+      marks
+    end
+
+    def self.get_range (code, start, endline)
+      length    = code.lines.count
+      start   ||= 1
+      endline ||= length
+      if start > 1 or endline < length
+        raise "#{filepath} is #{length} lines long, cannot begin at line #{start}" if start > length
+        raise "#{filepath} is #{length} lines long, cannot read beyond line #{endline}" if endline > length
+        code = code.split(/\n/).slice(start - 1, endline + 1 - start).join("\n")
+      end
+      code
+    end
+
+    def self.highlight_failed(error, syntax, markup, code, file = nil)
+      code_snippet = code.split("\n")[0..9].map{|l| "    #{l}" }.join("\n")
+      fail_message  = "\nPygments Error while parsing the following markup#{" in #{file}" if file}:\n\n".red
+      fail_message += "    #{markup}\n#{code_snippet}\n"
+      fail_message += "#{"    ..." if code.split("\n").size > 10}\n"
+      fail_message += "\nValid Syntax:\n\n#{syntax}\n".yellow
+      fail_message += "\nPygments Error:\n\n#{error.message}".red
+      $stderr.puts fail_message.chomp
+      raise ArgumentError
+    end
   end
 end
+


### PR DESCRIPTION
This is only for people who wants "start, mark" in the code block in 2.0 (master).

As I can't run branch 2.5 on my Windows machine.

As it looks like most of the development effort are now in 3.0, therefore I decided to merge only the corresponding plugins from 2.5 to `master`, I also updated the default theme as `master` doesn't support for line number. 

Reference I used include Ricardos code:
https://groups.google.com/d/msg/octopress/y1IlHmFYydQ/MCSBrDrL1XIJ
