### PR TITLE
Allow username/shorttag/revision format

### DIFF
--- a/plugins/jsfiddle.rb
+++ b/plugins/jsfiddle.rb
@@ -18,7 +18,7 @@
 module Jekyll
   class JsFiddle < Liquid::Tag
     def initialize(tag_name, markup, tokens)
-      if /(?<fiddle>\w+\/?\d?)(?:\s+(?<sequence>[\w,]+))?(?:\s+(?<skin>\w+))?(?:\s+(?<height>\w+))?(?:\s+(?<width>\w+))?/ =~ markup
+      if /(?<fiddle>\S+\/?\d?)(?:\s+(?<sequence>[\w,]+))?(?:\s+(?<skin>\w+))?(?:\s+(?<height>\w+))?(?:\s+(?<width>\w+))?/ =~ markup
         @fiddle   = fiddle
         @sequence = (sequence unless sequence == 'default') || 'js,resources,html,css,result'
         @skin     = (skin unless skin == 'default') || 'light'


### PR DESCRIPTION
I was not able to get a revision fiddle embedded without username. So I modified the plugin to support this format too.
