### PR TITLE
Reversed update_style copy direction to correctly restore the sass.old/custom files to the new sass/custom folder

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -188,7 +188,7 @@ task :update_style, :theme do |t, args|
   mv "sass", "sass.old"
   puts "## Moved styles into sass.old/"
   cp_r "#{themes_dir}/"+theme+"/sass/", "sass", :remove_destination=>true
-  cp_r "sass.old/custom/.", "sass.old/custom/", :remove_destination=>true
+  cp_r "sass.old/custom/.", "sass/custom/", :remove_destination=>true
   puts "## Updated Sass ##"
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -187,8 +187,8 @@ task :update_style, :theme do |t, args|
   end
   mv "sass", "sass.old"
   puts "## Moved styles into sass.old/"
-  cp_r "#{themes_dir}/"+theme+"/sass/", "sass"
-  cp_r "sass/custom/.", "sass.old/custom"
+  cp_r "#{themes_dir}/"+theme+"/sass/", "sass", :remove_destination=>true
+  cp_r "sass.old/custom/.", "sass.old/custom/", :remove_destination=>true
   puts "## Updated Sass ##"
 end
 


### PR DESCRIPTION
Also uses remove_destination to clean out old files on the copy to bring behavior in line with update_source.

Fixes #1488
