### PR TITLE
Handle multiple redirects for gist_tag

### DIFF
--- a/plugins/gist_tag.rb
+++ b/plugins/gist_tag.rb
@@ -78,10 +78,6 @@ module Jekyll
       gist_url = get_gist_url_for(gist, file)
       data     = get_web_content(gist_url)
 
-      if data.code.to_i == 302
-        data = handle_gist_redirecting(data)
-      end
-
       if data.code.to_i != 200
         raise RuntimeError, "Gist replied with #{data.code} for #{gist_url}"
       end
@@ -111,6 +107,12 @@ module Jekyll
       https.verify_mode = OpenSSL::SSL::VERIFY_NONE
       request           = Net::HTTP::Get.new raw_uri.request_uri
       data              = https.request request
+
+      if data.code.to_i == 301 || data.code.to_i == 302
+        data = handle_gist_redirecting(data)
+      end
+
+      data
     end
   end
 


### PR DESCRIPTION
GitHub Gist now redirects a few times to get to the eventual raw code. This handles it recursively rather than expecting 2 redirects, and is an alternative to #1503.

[fixes #1502]
