### PR TITLE
Changed regex to match https urls so https deploy works

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -322,7 +322,7 @@ task :setup_github_pages, :repo do |t, args|
     user = repo_url.match(/github\.com\/([^\/]+)/)[1]
   end
   branch = (repo_url.match(/\/[\w-]+\.github\.(?:io|com)/).nil?) ? 'gh-pages' : 'master'
-  project = (branch == 'gh-pages') ? repo_url.match(/\/([^\.]+)/)[1] : ''
+  project = (branch == 'gh-pages') ? repo_url.match(/\/([^\/]+)\.git/)[1] : ''
   unless (`git remote -v` =~ /origin.+?octopress(?:\.git)?/).nil?
     # If octopress is still the origin remote (from cloning) rename it to octopress
     system "git remote rename origin octopress"


### PR DESCRIPTION
Original regex was matching from //github section of https urls to end of url during deploy, causing the site's root directory and theme resource paths to be wrong.

An example of an URL that wouldn't work with the previous regex is https://github.com/imathis/octopress. With the fixed regex, this URL will work.

An example of what a blog looks like if an https URL is used before the regex fix was applied: http://skbruck.github.io/octotest1/
An example of what a blog looks like if an https URL is used after the regex fix was applied: http://skbruck.github.io/octotest2/
