### PR TITLE
Allow empty or nil categories to be processed

### DIFF
--- a/plugins/category_generator.rb
+++ b/plugins/category_generator.rb
@@ -153,7 +153,7 @@ ERR
     # Returns string
     #
     def category_links(categories)
-      categories = categories.sort!.map { |c| category_link c }
+      categories = categories.to_a.sort!.map { |c| category_link c }
 
       case categories.length
       when 0


### PR DESCRIPTION
After this we can create bit more condensed templates like:

```
{% capture category_links %}{{ post.categories | category_links }}{{ page.categories | category_links }}{% endcapture %}
```
