### PR TITLE
Retain starting whitespaces of first line on backtick code block

### DIFF
--- a/plugins/backtick_code_block.rb
+++ b/plugins/backtick_code_block.rb
@@ -22,9 +22,6 @@ module BacktickCodeBlock
         @caption = "<figcaption><span>#{$2}</span></figcaption>"
       end
 
-      if str.match(/\A( {4}|\t)/)
-        str = str.gsub(/^( {4}|\t)/, '')
-      end
       if @lang.nil? || @lang == 'plain'
         code = tableize_code(str.gsub('<','&lt;').gsub('>','&gt;'))
         "<figure class='code'>#{@caption}#{code}</figure>"


### PR DESCRIPTION
It's not good for raw text code block. If the first spaces/tab should be removed, just remove it from source.
