### PR TITLE
Ruby ~> 1.9 hash syntax

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -123,7 +123,7 @@ end
 desc "Create a new page in #{source_dir}/(filename)/index.#{new_page_ext}"
 task :new_page, :filename do |t, args|
   raise "### You haven't set anything up yet. First run `rake install` to set up an Octopress theme." unless File.directory?(source_dir)
-  args.with_defaults(:filename => 'new-page')
+  args.with_defaults(filename: 'new-page')
   page_dir = [source_dir]
   if args.filename.downcase =~ /(^.+\/)?(.+)/
     filename, dot, extension = $2.rpartition('.').reject(&:empty?)         # Get filename and extension
@@ -183,12 +183,12 @@ task :update_style, :theme do |t, args|
   theme = args.theme || 'classic'
   if File.directory?("sass.old")
     puts "removed existing sass.old directory"
-    rm_r "sass.old", :secure=>true
+    rm_r "sass.old", secure: true
   end
   mv "sass", "sass.old"
   puts "## Moved styles into sass.old/"
-  cp_r "#{themes_dir}/"+theme+"/sass/", "sass", :remove_destination=>true
-  cp_r "sass.old/custom/.", "sass/custom/", :remove_destination=>true
+  cp_r "#{themes_dir}/"+theme+"/sass/", "sass", remove_destination: true
+  cp_r "sass.old/custom/.", "sass/custom/", remove_destination: true
   puts "## Updated Sass ##"
 end
 
@@ -197,15 +197,15 @@ task :update_source, :theme do |t, args|
   theme = args.theme || 'classic'
   if File.directory?("#{source_dir}.old")
     puts "## Removed existing #{source_dir}.old directory"
-    rm_r "#{source_dir}.old", :secure=>true
+    rm_r "#{source_dir}.old", secure: true
   end
   mkdir "#{source_dir}.old"
   cp_r "#{source_dir}/.", "#{source_dir}.old"
   puts "## Copied #{source_dir} into #{source_dir}.old/"
-  cp_r "#{themes_dir}/"+theme+"/source/.", source_dir, :remove_destination=>true
-  cp_r "#{source_dir}.old/_includes/custom/.", "#{source_dir}/_includes/custom/", :remove_destination=>true
+  cp_r "#{themes_dir}/"+theme+"/source/.", source_dir, remove_destination: true
+  cp_r "#{source_dir}.old/_includes/custom/.", "#{source_dir}/_includes/custom/", remove_destination: true
   cp "#{source_dir}.old/favicon.png", source_dir
-  mv "#{source_dir}/index.html", "#{blog_index_dir}", :force=>true if blog_index_dir != source_dir
+  mv "#{source_dir}/index.html", "#{blog_index_dir}", force: true if blog_index_dir != source_dir
   cp "#{source_dir}.old/index.html", source_dir if blog_index_dir != source_dir && File.exists?("#{source_dir}.old/index.html")
   puts "## Updated #{source_dir} ##"
 end
@@ -228,7 +228,7 @@ task :deploy do
 end
 
 desc "Generate website and deploy"
-task :gen_deploy => [:integrate, :generate, :deploy] do
+task gen_deploy: [:integrate, :generate, :deploy] do
 end
 
 desc "copy dot files for deployment"

--- a/config.ru
+++ b/config.ru
@@ -11,7 +11,7 @@ class SinatraStaticServer < Sinatra::Base
   end
 
   not_found do
-    send_file(File.join(File.dirname(__FILE__), 'public', '404.html'), {:status => 404})
+    send_file(File.join(File.dirname(__FILE__), 'public', '404.html'), {status: 404})
   end
 
   def send_sinatra_file(path, &missing_file_block)


### PR DESCRIPTION
Refactored to new ruby hash syntax, since Octopress uses -> Ruby 1.9.3 as per [documentation](http://octopress.org/docs/setup/)
Simplifies the code and makes it more succinct.

It does not modify any of the plugins' syntax, as it seems a little bit third-party-ish to me.
