### PR TITLE
Add a capture to article include to use external-url

### DIFF
--- a/.themes/classic/source/_includes/article.html
+++ b/.themes/classic/source/_includes/article.html
@@ -10,8 +10,8 @@
       <p class="meta">
         {% include post/date.html %}{{ time }}
         {% if site.disqus_short_name and page.comments != false and post.comments != false and site.disqus_show_comment_count == true %}
-         | <a href="{% if index %}{{ root_url }}{{ post.url }}{% endif %}#disqus_thread"
-			 data-disqus-identifier="{% if post.meta.disqus_id %}{{ post.meta.disqus_id }}{% else %}{{ site.url }}{{ post.url }}{% endif %}">Comments</a>
+           | <a href="{% if index %}{{ root_url }}{{ post.url }}{% endif %}#disqus_thread"
+             data-disqus-identifier="{% if post.meta.disqus_id %}{{ post.meta.disqus_id }}{% else %}{{ site.url }}{{ post.url }}{% endif %}">Comments</a>
         {% endif %}
         {% if post.external_url %}<a href="{{ root_url }}{{ post.url }}">Permalink</a>{% endif %}
       </p>

--- a/.themes/classic/source/_includes/article.html
+++ b/.themes/classic/source/_includes/article.html
@@ -1,7 +1,8 @@
 {% unless page.no_header %}
   <header>
     {% if index %}
-      <h1 class="entry-title"><a href="{{ root_url }}{{ post.url }}">{% if site.titlecase %}{{ post.title | titlecase }}{% else %}{{ post.title }}{% endif %}</a></h1>
+      {% capture entryhref %}{% if post.external_url %}{{ post.external_url }}{% else %}{{ root_url}}{{ post.url }}{% endif %}{% endcapture %}
+      <h1 class="entry-title"><a href="{{ entryhref }}">{% if site.titlecase %}{{ post.title | titlecase }}{% else %}{{ post.title }}{% endif %}</a></h1>
     {% else %}
       <h1 class="entry-title">{% if site.titlecase %}{{ page.title | titlecase }}{% else %}{{ page.title }}{% endif %}</h1>
     {% endif %}
@@ -9,9 +10,10 @@
       <p class="meta">
         {% include post/date.html %}{{ time }}
         {% if site.disqus_short_name and page.comments != false and post.comments != false and site.disqus_show_comment_count == true %}
-           | <a href="{% if index %}{{ root_url }}{{ post.url }}{% endif %}#disqus_thread"
-             data-disqus-identifier="{% if post.meta.disqus_id %}{{ post.meta.disqus_id }}{% else %}{{ site.url }}{{ post.url }}{% endif %}">Comments</a>
+         | <a href="{% if index %}{{ root_url }}{{ post.url }}{% endif %}#disqus_thread"
+			 data-disqus-identifier="{% if post.meta.disqus_id %}{{ post.meta.disqus_id }}{% else %}{{ site.url }}{{ post.url }}{% endif %}">Comments</a>
         {% endif %}
+        {% if post.external_url %}<a href="{{ root_url }}{{ post.url }}">Permalink</a>{% endif %}
       </p>
     {% endunless %}
   </header>


### PR DESCRIPTION
I tried using the `external-url` feature as described in the [docs for writing a linklog](http://octopress.org/docs/blogging/linklog/). 

It didn't work for me, so I looked into the includes and made this change for myself. It seems to work, although I'm not sure if it's in 100% alignment with the project goals or if there are other parts of Octopress that I am not properly accounting for. 

Anyway, for what it's worth...
