### PR TITLE
The stringex gem is required by Heroku, proposing moving it outside the development group.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,9 @@ group :development do
   gem 'sass-globbing', '~> 1.0.0'
   gem 'rubypants', '~> 0.2.0'
   gem 'rb-fsevent', '~> 0.9'
-  gem 'stringex', '~> 1.4.0'
   gem 'liquid', '~> 2.3.0'
   gem 'directory_watcher', '1.4.1'
 end
 
 gem 'sinatra', '~> 1.4.2'
+gem 'stringex', '~> 1.4.0'


### PR DESCRIPTION
In order to solve this [issue](https://github.com/imathis/octopress/issues/1439), I propose moving the stringex gem outside of the development group in the Gemfile.
