### PR TITLE
Enable Coffee syntax highlighting

### DIFF
--- a/plugins/pygments_code.rb
+++ b/plugins/pygments_code.rb
@@ -11,6 +11,7 @@ module HighlightCode
     lang = 'objc' if lang == 'm'
     lang = 'perl' if lang == 'pl'
     lang = 'yaml' if lang == 'yml'
+    lang = 'coffeescript' if lang == 'coffee'
     str = pygments(str, lang).match(/<pre>(.+)<\/pre>/m)[1].to_s.gsub(/ *$/, '') #strip out divs <div class="highlight">
     tableize_code(str, lang)
   end


### PR DESCRIPTION
I add lang name conversion for coffee-script.

The extension of CoffeeScript is "*.coffee",
but the short names of Pygments is "coffee-script, coffeescript".

http://pygments.org/docs/lexers/#pygments.lexers.web.CoffeeScriptLexer
