### PR TITLE
Use correct time in log message for Github deploy

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -261,8 +261,8 @@ multitask :push do
   cp_r "#{public_dir}/.", deploy_dir
   cd "#{deploy_dir}" do
     system "git add -A"
-    puts "\n## Committing: Site updated at #{Time.now.utc}"
     message = "Site updated at #{Time.now.utc}"
+    puts "\n## Committing: #{message}"
     system "git commit -m \"#{message}\""
     puts "\n## Pushing generated #{deploy_dir} website"
     system "git push origin #{deploy_branch}"


### PR DESCRIPTION
It's a very minor detail, but it's theoretically possible that `Time.now.utc` could advance by a second between the `puts` and the `git commit`.
