### PR TITLE
Update gist tag url to githubusercontent.com

### DIFF
--- a/plugins/gist_tag.rb
+++ b/plugins/gist_tag.rb
@@ -44,7 +44,7 @@ module Jekyll
     end
 
     def script_url_for(gist_id, filename)
-      url = "https://gist.githubusercontent.com/#{gist_id}.js"
+      url = "https://gist.github.com/#{gist_id}.js"
       url = "#{url}?file=#{filename}" unless filename.nil? or filename.empty?
       url
     end


### PR DESCRIPTION
The old url will return error code 301.
