### PR TITLE
Replace response code check with class object check

### DIFF
--- a/plugins/gist_tag.rb
+++ b/plugins/gist_tag.rb
@@ -79,13 +79,13 @@ module Jekyll
       data     = get_web_content(gist_url)
 
       locations = Array.new
-      while (data.code.to_i == 301 || data.code.to_i == 302)
+      while data.is_a?(Net::HTTPRedirection)
         data = handle_gist_redirecting(data)
         break if locations.include? data.header['Location']
         locations << data.header['Location']
       end
 
-      if data.code.to_i != 200
+      unless data.is_a?(Net::HTTPSuccess)
         raise RuntimeError, "Gist replied with #{data.code} for #{gist_url}"
       end
 


### PR DESCRIPTION
When querying, the response return is of sublcass of HTTPResponse, thus we could check based on the subclass type
