### PR TITLE
Added a brief warning not to create new themes via the /sass/custom/* files

### DIFF
--- a/.themes/classic/sass/custom/_colors.scss
+++ b/.themes/classic/sass/custom/_colors.scss
@@ -1,4 +1,5 @@
 // Here you can easily change your sites's color scheme.
+// !!!Please leave this file FULLY COMMENTED if you intend to create a new theme!!!
 // To give it a try, uncomment some of the lines below rebuild your blog, and see how it works.
 // If you need a handy color picker try http://hslpicker.com
 

--- a/.themes/classic/sass/custom/_fonts.scss
+++ b/.themes/classic/sass/custom/_fonts.scss
@@ -1,4 +1,5 @@
 // Here you can easily change font faces which are used in your site.
+// !!!Please leave this file FULLY COMMENTED if you intend to create a new theme!!!
 // To give it a try, uncomment some of the lines below rebuild your blog, and see how it works. your sites's.
 // If you love to use Web Fonts, you also need to add some lines to source/_includes/custom/head.html
 

--- a/.themes/classic/sass/custom/_layout.scss
+++ b/.themes/classic/sass/custom/_layout.scss
@@ -1,4 +1,5 @@
 // Here you can easily change your sites's layout.
+// !!!Please leave this file FULLY COMMENTED if you intend to create a new theme!!!
 // To give it a try, uncomment some of the lines below, make changes, rebuild your blog, and see how it works.
 
 //$header-font-size: 1em;

--- a/.themes/classic/sass/custom/_styles.scss
+++ b/.themes/classic/sass/custom/_styles.scss
@@ -1,2 +1,3 @@
 // This File is imported last, and will override other styles in the cascade
+// !!!Please leave this file FULLY COMMENTED if you intend to create a new theme!!!
 // Add styles here to make changes without digging in too much

--- a/.themes/classic/source/_includes/google_analytics.html
+++ b/.themes/classic/source/_includes/google_analytics.html
@@ -6,7 +6,7 @@
 
     (function() {
       var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+      ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
       var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
     })();
   </script>

--- a/.themes/classic/source/_includes/google_analytics.html
+++ b/.themes/classic/source/_includes/google_analytics.html
@@ -6,7 +6,7 @@
 
     (function() {
       var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-      ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
+      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
       var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
     })();
   </script>


### PR DESCRIPTION
As described in [this discussion](https://github.com/imathis/octopress/issues/1478), users should be advised not to abuse the "custom" feature in order to create new themes, as this would:
- Unnecessarily bloat the resulting themes
- Make end-user customization more difficult
