### PR TITLE
Fix jquery.min.js via non-cdn

### DIFF
--- a/.themes/classic/source/_includes/head.html
+++ b/.themes/classic/source/_includes/head.html
@@ -23,7 +23,7 @@
   <link href="{{ site.subscribe_rss }}" rel="alternate" title="{{site.title}}" type="application/atom+xml">
   <script src="{{ root_url }}/javascripts/modernizr-2.0.js"></script>
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-  <script>window.jQuery || document.write('<script src="/javascripts/libs/jquery.min.js"><\/script>')</script>
+  <script>window.jQuery || document.write('<script src="{{ root_url }}/javascripts/libs/jquery.min.js"><\/script>')</script>
   <script src="{{ root_url }}/javascripts/octopress.js" type="text/javascript"></script>
   {% include custom/head.html %}
   {% include google_analytics.html %}


### PR DESCRIPTION
Due to `./` in  `src="./javascripts/libs/jquery.min.js"`, this was causes 404 requests, as it was using relatives paths on all subfolders.

At the same time, I didn't like the logic (felt double negative to me), so altered it to match [HTML5 boilerplate](https://github.com/h5bp/html5-boilerplate/).
