### PR TITLE
Fix Gist embedded code layout

### DIFF
--- a/.themes/classic/sass/partials/_syntax.scss
+++ b/.themes/classic/sass/partials/_syntax.scss
@@ -1,5 +1,5 @@
 .highlight, html .gist .gist-file .gist-syntax .gist-highlight {
-  table td.code { width: 100%; }
+  table td.code, td.line-data { width: 100%; }
   border: 1px solid $pre-border !important;
 }
 .highlight .line-numbers, html .gist .gist-file .gist-syntax .highlight .line_numbers {
@@ -46,6 +46,7 @@ html .gist .gist-file {
     }
     .highlight pre {
       @extend .pre-code;
+      font-size: 13px;
       padding: 0;
     }
   }
@@ -69,7 +70,7 @@ html .gist .gist-file {
       &:hover { color: $base1 !important; }
     }
     a[href*='#file'] {
-      position: absolute; top: 0; left:0; right:-10px;
+      position: absolute; top: 0; left:0; right:0;
       color: #474747 !important;
       @extend .code-title;
       &:hover { color: $link-color !important; }


### PR DESCRIPTION
- Gist code has `td.line-data` instead of `td.code`.
  - When every code line is shorter than table width, its background does not cover the table.
- Font size of code is not `13px`.
- Gist title bar is `10px` longer than its content table.
