### PR TITLE
Adding Rakefile to .slugignore

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,3 +1,4 @@
 plugins
 sass
 source
+Rakefile


### PR DESCRIPTION
Resolves issue where Heroku deploy throws an benign error because Rakefile requires a :development group dependency (stringex)
