### PR TITLE
Escape double quotes of the post title

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -111,7 +111,7 @@ task :new_post, :title do |t, args|
   open(filename, 'w') do |post|
     post.puts "---"
     post.puts "layout: post"
-    post.puts "title: \"#{title.gsub(/&/,'&amp;')}\""
+    post.puts "title: \"#{title.gsub(/&/,'&amp;').gsub(/"/, "\\\"")}\""
     post.puts "date: #{Time.now.strftime('%Y-%m-%d %H:%M:%S %z')}"
     post.puts "comments: true"
     post.puts "categories: "


### PR DESCRIPTION
This is how to produce this problem.
1. Run `rake new_post` with a title that has double quotes:
   
   ```
   $ rake new_post
   Enter a title for your post: Post with "double quotes"
   mkdir -p source/_posts
   Creating new post: source/_posts/2014-07-12-post-with-double-quotes.markdown
   ```
   
   either
   
   ```
   $ rake new_post["Post with \"double quotes\""]
   mkdir -p source/_posts
   Creating new post: source/_posts/2014-07-12-post-with-double-quotes.markdown
   ```
   
   Then the content of `2014-07-12-post-with-double-quotes.markdown`:
   
   ``` yml
   ---
   layout: post
   title: "Post with "double quotes""
   date: 2014-07-12 00:00:00 +0000
   comments: true
   categories: 
   ---
   ```
2. Run `rake generate`:
   
   ```
   $ rake generate
   ## Generating Site with Jekyll
   identical source/stylesheets/screen.css
   Configuration file: /path/to/octopress/_config.yml
               Source: source
          Destination: public
         Generating...
   Error reading file /path/to/octopress/source/_posts/2014-07-12-post-with-double-quotes.markdown: (<unknown>): did not find expected key while parsing a block mapping at line 2 column 1
                       done.
   ```
