### PR TITLE
Fixes load path issues with ruby-based git credential helpers

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -253,7 +253,7 @@ multitask :push do
   puts "## Deploying branch to Github Pages "
   puts "## Pulling any updates from Github Pages "
   cd "#{deploy_dir}" do 
-    system "git pull"
+    Bundler.with_clean_env { system "git pull" }
   end
   (Dir["#{deploy_dir}/*"]).each { |f| rm_rf(f) }
   Rake::Task[:copydot].invoke(public_dir, deploy_dir)
@@ -265,7 +265,7 @@ multitask :push do
     puts "\n## Committing: #{message}"
     system "git commit -m \"#{message}\""
     puts "\n## Pushing generated #{deploy_dir} website"
-    system "git push origin #{deploy_branch}"
+    Bundler.with_clean_env { system "git push origin #{deploy_branch}" }
     puts "\n## Github Pages deploy complete"
   end
 end


### PR DESCRIPTION
Otherwise, we get errors like this (with boxen, e.g.):

```
/opt/boxen/bin/boxen-git-credential:23:in `require': cannot load such file -- boxen/config (LoadError)
        from /opt/boxen/bin/boxen-git-credential:23:in `<main>'
Username for 'https://github.com':
```

/cc: @dgoodlad
