### PR TITLE
.gitignore Gemfile.lock per previous commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ source/_stash
 source/stylesheets/screen.css
 vendor
 node_modules
+Gemfile.lock


### PR DESCRIPTION
Gemfile.lock was removed in a previous commit, should be ignored so it doesn't get committed again.

https://github.com/imathis/octopress/commit/06c04397053e46fe02fcecce589a2de76d21e160
