### PR TITLE
remove deprecated gems 'jekyll-page-hooks' and 'jekyll-date-format'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@ source "https://rubygems.org"
 group :development do
   gem 'rake', '~> 10.0'
   gem 'jekyll', '~> 2.0'
-  gem 'jekyll-page-hooks', '~> 1.2'
-  gem 'jekyll-date-format', '~> 1.0'
+  gem 'octopress-hooks', '~> 2.2.0'
+  gem 'octopress-date-format', '~> 2.0.0'
   gem 'jekyll-sitemap'
   gem 'rdiscount', '~> 2.0'
   gem 'RedCloth', '~> 4.2.9'

--- a/plugins/octopress_filters.rb
+++ b/plugins/octopress_filters.rb
@@ -1,8 +1,8 @@
 #custom filters for Octopress
 require './plugins/backtick_code_block'
-require 'jekyll-page-hooks'
+require 'octopress-hooks'
 require 'jekyll-sitemap'
-require 'jekyll-date-format'
+require 'octopress-date-format'
 require './plugins/raw'
 require 'rubypants'
 


### PR DESCRIPTION
'jekyll-page-hooks' is renamed to 'octopress-hooks' and 'jekyll-date-format' to 'octopress-date-format'
