### PR TITLE
Replaced references to date_formatted with date_text in the classic theme

### DIFF
--- a/.themes/classic/source/_includes/post/date.html
+++ b/.themes/classic/source/_includes/post/date.html
@@ -1,15 +1,15 @@
 {% capture date %}{{ page.date }}{{ post.date }}{% endcapture %}
-{% capture date_formatted %}{{ page.date_formatted }}{{ post.date_formatted }}{% endcapture %}
+{% capture date_text %}{{ page.date_text }}{{ post.text }}{% endcapture %}
 {% capture has_date %}{{ date | size }}{% endcapture %}
 
 {% capture updated %}{{ page.updated }}{{ post.updated }}{% endcapture %}
-{% capture updated_formatted %}{{ page.updated_formatted }}{{ post.updated_formatted }}{% endcapture %}
+{% capture updated_text %}{{ page.updated_text }}{{ post.updated_text }}{% endcapture %}
 {% capture was_updated %}{{ updated | size }}{% endcapture %}
 
 {% if has_date != '0' %}
-  {% capture time %}<time datetime="{{ date | datetime | date_to_xmlschema }}" pubdate{% if updated %} data-updated="true"{% endif %}>{{ date_formatted }}</time>{% endcapture %}
+  {% capture time %}<time datetime="{{ date | datetime | date_to_xmlschema }}" pubdate{% if updated %} data-updated="true"{% endif %}>{{ date_text }}</time>{% endcapture %}
 {% endif %}
 
 {% if was_updated != '0' %}
-  {% capture updated %}<time datetime="{{ updated | datetime | date_to_xmlschema }}" class="updated">Updated {{ updated_formatted }}</time>{% endcapture %}
+  {% capture updated %}<time datetime="{{ updated | datetime | date_to_xmlschema }}" class="updated">Updated {{ updated_text }}</time>{% endcapture %}
 {% else %}{% assign updated = false %}{% endif %}


### PR DESCRIPTION
Since the `date.rb` plugin were replaced with the `jekyll-date-plugin`, the post timestamps in the classic theme were not being rendered correctly anymore.

This commit fixes that issues.
