### PR TITLE
Fix Jekyll date format from _config.yml

### DIFF
--- a/.themes/classic/source/_includes/post/date.html
+++ b/.themes/classic/source/_includes/post/date.html
@@ -1,5 +1,15 @@
-{% if page.date %}{% capture time %}{{ page.date_time_html }}{% endcapture %}{% endif %}
-{% if post.date %}{% capture time %}{{ post.date_time_html }}{% endcapture %}{% endif %}
+{% capture date %}{{ page.date }}{{ post.date }}{% endcapture %}
+{% capture date_formatted %}{{ page.date | date: site.date_format }}{{ post.date | date: site.date_format }}{% endcapture %}
+{% capture has_date %}{{ date | size }}{% endcapture %}
 
-{% if page.updated %}{% capture updated %}{{ page.date_time_updated_html }}{% endcapture %}{% endif %}
-{% if post.updated %}{% capture updated %}{{ post.date_time_updated_html }}{% endcapture %}{% endif %}
+{% capture updated %}{{ page.updated }}{{ post.updated }}{% endcapture %}
+{% capture updated_formatted %}{{ page.updated | date: site.date_format }}{{ post.updated | date: site.date_format }}{% endcapture %}
+{% capture was_updated %}{{ updated | size }}{% endcapture %}
+
+{% if has_date != '0' %}
+  {% capture time %}<time datetime="{{ date | datetime | date_to_xmlschema }}" pubdate{% if updated %} data-updated="true"{% endif %}>{{ date_formatted }}</time>{% endcapture %}
+{% endif %}
+
+{% if was_updated != '0' %}
+  {% capture updated %}<time datetime="{{ updated | datetime | date_to_xmlschema }}" class="updated">Updated {{ updated_formatted }}</time>{% endcapture %}
+{% else %}{% assign updated = false %}{% endif %}


### PR DESCRIPTION
I took _page.html_ from commit [987dcce](https://github.com/imathis/octopress/blob/987dccee7655a410a2fb1e0f41c35b282b17cbe9/.themes/classic/source/_includes/post/date.html) and fix applying date format from __config.yml_
