### PR TITLE
Rubypants: avoid to "educate_dashes" HTML comments close tags.

### DIFF
--- a/plugins/rubypants.rb
+++ b/plugins/rubypants.rb
@@ -344,7 +344,7 @@ class RubyPants < String
   # em-dash HTML entity.
   #
   def educate_dashes(str)
-    str.gsub(/--/, '&#8212;')
+    str.gsub(/--(?!>)/, '&#8212;')
   end
 
   # The string, with each instance of "<tt>--</tt>" translated to an
@@ -352,7 +352,7 @@ class RubyPants < String
   # em-dash HTML entity.
   #
   def educate_dashes_oldschool(str)
-    str.gsub(/---/, '&#8212;').gsub(/--/, '&#8211;')
+    str.gsub(/---(?!>)/, '&#8212;').gsub(/--(?!>)/, '&#8211;')
   end
 
   # Return the string, with each instance of "<tt>--</tt>" translated
@@ -366,7 +366,7 @@ class RubyPants < String
   # Aaron Swartz for the idea.)
   #
   def educate_dashes_inverted(str)
-    str.gsub(/---/, '&#8211;').gsub(/--/, '&#8212;')
+    str.gsub(/---(?!>)/, '&#8211;').gsub(/--(?!>)/, '&#8212;')
   end
 
   # Return the string, with each instance of "<tt>...</tt>" translated


### PR DESCRIPTION
I'm unsure of the fix, but here are the step to trigger the bug:

```
% git clone https://github.com/imathis/octopress.git && cd octopress
% rake install
% curl https://gist.githubusercontent.com/kAworu/0a06ac86fbd819714d52/raw/975aeffdd67b8b932d550e46fe00877ea22f3caf/head.patch | patch -p0
% rake preview # oups.
```
