### PR TITLE
updated compass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :development do
   gem 'rdiscount', '~> 2.0'
   gem 'RedCloth', '~> 4.2.9'
   gem 'haml', '~> 4.0'
-  gem 'compass', '~> 0.12.2'
+  gem 'compass', '~> 1.0.1'
   gem 'sass-globbing', '~> 1.0.0'
   gem 'rubypants', '~> 0.2.0'
   gem 'rb-fsevent', '~> 0.9'


### PR DESCRIPTION
Compass was updated because I had to use `bourbon` and `neat`.
The `1.0.1` version works with octopress normally.

The follow error is happening in version `0.12.2` of compass:

```
error sass/screen.scss (Line 21 of vendor/bower/bourbon/dist/helpers/_linear-angle-parser.scss: Invalid CSS after "      webkit-image": expected ")", was ": -webkit- + $p...")
```
