### PR TITLE
Render unpublished posts (Fix #1675)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -78,10 +78,20 @@ end
 
 desc "preview the site in a web browser"
 task :preview do
+  preview_site(source_dir, server_port)
+end
+
+desc "preview the site including unpublished posts in a web browser"
+task :preview_all do
+  preview_site(source_dir, server_port, "--unpublished")
+end
+
+def preview_site(source_dir, server_port, *options)
   raise "### You haven't set anything up yet. First run `rake install` to set up an Octopress theme." unless File.directory?(source_dir)
+  touch ".preview-mode"
   puts "Starting to watch source with Jekyll and Compass. Starting Rack on port #{server_port}"
   system "compass compile --css-dir #{source_dir}/stylesheets" unless File.exist?("#{source_dir}/stylesheets/screen.css")
-  jekyllPid = Process.spawn({"OCTOPRESS_ENV"=>"preview"}, "jekyll build --watch")
+  jekyllPid = Process.spawn({"OCTOPRESS_ENV"=>"preview"}, (%w(jekyll build --watch) + options).join(" "))
   compassPid = Process.spawn("compass watch")
   rackupPid = Process.spawn("rackup --port #{server_port}")
 


### PR DESCRIPTION
Fix #1675.

Based on the [documentation](http://octopress.org/docs/blogging/), we should be able to preview posts having `published: false` in its YAML header.