### PR TITLE
Add link to add site to the wiki

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -38,4 +38,4 @@ THE SOFTWARE IS PROVIDED ‘AS IS’, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 
 #### If you want to be awesome.
 - Proudly display the 'Powered by Octopress' credit in the footer.
-- Add your site to the Wiki so we can watch the community grow.
+- [Add your site to the Wiki](https://github.com/imathis/octopress/wiki/Octopress-Sites/_edit) so we can watch the community grow.


### PR DESCRIPTION
So that more people will do it and it'll take less time. As long as we trust people, that's good I guess.
