### PR TITLE
Fix site search form to work with Google

### DIFF
--- a/.themes/classic/source/_includes/navigation.html
+++ b/.themes/classic/source/_includes/navigation.html
@@ -5,10 +5,10 @@
   {% endif %}
 </ul>
   {% if site.simple_search %}
-<form action="{{ site.simple_search }}" method="get">
+<form action="{{ site.simple_search }}" method="get" onsubmit="this['q'].value = this['q_raw'].value + ' site:{{ site.url | shorthand_url }}';">
   <fieldset role="search">
-    <input type="hidden" name="q" value="site:{{ site.url | shorthand_url }}" />
-    <input class="search" type="text" name="q" results="0" placeholder="Search"/>
+    <input type="hidden" name="q" value="" />
+    <input class="search" type="text" name="q_raw" results="0" placeholder="Search"/>
   </fieldset>
 </form>
   {% endif %}


### PR DESCRIPTION
Around beginning of November 2014 Octopress site search stopped working with Google, as you can see yourself by going to octopress.org and entering a search query.

The problem is apparently two 'q' inputs in the form. This commit fixes the problem by building q dynamically at submit time - the proper query and "site:yoursite.com" get concatenated in javascript to produce the desired effect.
