### PR TITLE
rake: Add rakefile parameter to set git message

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -261,7 +261,7 @@ multitask :push do
   cp_r "#{public_dir}/.", deploy_dir
   cd "#{deploy_dir}" do
     system "git add -A"
-    message = "Site updated at #{Time.now.utc}"
+    message = ENV["message"] || "Site updated at #{Time.now.utc}"
     puts "\n## Committing: #{message}"
     system "git commit -m \"#{message}\""
     puts "\n## Pushing generated #{deploy_dir} website"


### PR DESCRIPTION
Add a rakefile parameter called "message" to set a custom git commit
message for a deploy.

Example:

```
rake deploy message="This is a custom commit message"
```
