### PR TITLE
Show a more meaningful error message when `rake isolate` is called

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -161,7 +161,7 @@ end
 # usage rake isolate[my-post]
 desc "Move all other posts than the one currently being worked on to a temporary stash location (stash) so regenerating the site happens much more quickly."
 task :isolate, :filename do |t, args|
-  puts ">>> !! Please provide a fillename, eg. rake isolate[my_post]" unless args.filename?
+  puts ">>> !! Please provide a filename, eg. rake isolate[my_post]" unless args.filename?
   if args.filename?
     stash_dir = "#{source_dir}/#{stash_dir}"
     FileUtils.mkdir(stash_dir) unless File.exist?(stash_dir)

--- a/Rakefile
+++ b/Rakefile
@@ -161,10 +161,13 @@ end
 # usage rake isolate[my-post]
 desc "Move all other posts than the one currently being worked on to a temporary stash location (stash) so regenerating the site happens much more quickly."
 task :isolate, :filename do |t, args|
-  stash_dir = "#{source_dir}/#{stash_dir}"
-  FileUtils.mkdir(stash_dir) unless File.exist?(stash_dir)
-  Dir.glob("#{source_dir}/#{posts_dir}/*.*") do |post|
-    FileUtils.mv post, stash_dir unless post.include?(args.filename)
+  puts ">>> !! Please provide a fillename, eg. rake isolate[my_post]" unless args.filename?
+  if args.filename?
+    stash_dir = "#{source_dir}/#{stash_dir}"
+    FileUtils.mkdir(stash_dir) unless File.exist?(stash_dir)
+    Dir.glob("#{source_dir}/#{posts_dir}/*.*") do |post|
+      FileUtils.mv post, stash_dir unless post.include?(args.filename)
+    end
   end
 end
 


### PR DESCRIPTION
When calling `rake isolate` without a filename the following error is displayed, followed by a stacktrace:

    rake aborted!
    TypeError: no implicit conversion of nil into String

This PR adds a more meaningful message:

    >>> !! Please provide a filename, eg. rake isolate[my_post]