### PR TITLE
Create bash_completion for Octopress rake command options

### DIFF
--- a/utils/bash_completion/README.markdown
+++ b/utils/bash_completion/README.markdown
@@ -1,0 +1,21 @@
+# octopress_bash_completion
+This will auto complete options for used in [Octopress](http://octopress.org/)
+
+---
+# Install
+* copy rake to /etc/bash_completion.d/
+* relogin or `. /etc/bash_completion.d/rake`
+
+# Auto complete options
+* deploy 
+* generate 
+* preview 
+* watch 
+* new_post
+
+# Tested environment
+* Ubuntu 14.04
+
+# Reference
+* [An introduction to bash completion: part 1](http://www.debian-administration.org/article/316/An_introduction_to_bash_completion_part_1)
+* [An introduction to bash completion: part 2](http://www.debian-administration.org/article/317/An_introduction_to_bash_completion_part_2)

--- a/utils/bash_completion/rake
+++ b/utils/bash_completion/rake
@@ -1,0 +1,10 @@
+_rake() 
+{
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    opts="deploy generate preview watch new_post"
+
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+}
+complete -F _rake rake


### PR DESCRIPTION
bash_completion helps users to complete rake options in bash. For example, `rake g[tab]` will be completed to `rake generate`. 