### PR TITLE
update jsfiddle src to use current protocol

### DIFF
--- a/plugins/jsfiddle.rb
+++ b/plugins/jsfiddle.rb
@@ -29,7 +29,7 @@ module Jekyll
 
     def render(context)
       if @fiddle
-        "<iframe style=\"width: #{@width}; height: #{@height}\" frameborder=\"0\" seamless=\"seamless\" src=\"http://jsfiddle.net/#{@fiddle}/embedded/#{@sequence}/#{@skin}/\"></iframe>"
+        "<iframe style=\"width: #{@width}; height: #{@height}\" frameborder=\"0\" seamless=\"seamless\" src=\"//jsfiddle.net/#{@fiddle}/embedded/#{@sequence}/#{@skin}/\"></iframe>"
       else
         "Error processing input, expected syntax: {% jsfiddle shorttag [tabs] [skin] [height] [width] %}"
       end


### PR DESCRIPTION
JSFiddle should pull from `https://` at least when the current page is being viewed with https. Changing to `//` to use protocol of current page.