### PR TITLE
allow scrolling for code blocks on iOS devices

### DIFF
--- a/.themes/classic/sass/partials/_syntax.scss
+++ b/.themes/classic/sass/partials/_syntax.scss
@@ -209,6 +209,7 @@ $solar-scroll-thumb: rgba(#fff, .2);
 }
 
 pre, .highlight, .gist-highlight {
+  -webkit-overflow-scrolling: touch;
   &::-webkit-scrollbar {  height: .5em; background: $solar-scroll-bg; }
   &::-webkit-scrollbar-thumb:horizontal { background: $solar-scroll-thumb;  -webkit-border-radius: 4px; border-radius: 4px }
 }


### PR DESCRIPTION
Code blocks on iOS devices are not touch scrollable!
The only way to scroll code blocks on an iPhone is to try to touch the tiny
scroll bar and move it! In comparison to Android it is very complicated to view
octopress code!
To reproduce this error you need a native iOS device (or iOS simulator on OS X)
and open an octopress blog with Safari or Chrome.
A detailed description of this problem is described here:
http://drawingablank.me/blog/my-gripe-with-code-blocks.html