### PR TITLE
Show where pygments can't parse code

### DIFF
--- a/plugins/pygments_code.rb
+++ b/plugins/pygments_code.rb
@@ -24,7 +24,7 @@ module HighlightCode
         begin
           highlighted_code = Pygments.highlight(code, :lexer => lang, :formatter => 'html', :options => {:encoding => 'utf-8', :startinline => true})
         rescue MentosError
-          raise "Pygments can't parse unknown language: #{lang}."
+          raise "Pygments can't parse unknown language: #{lang}#{code}."
         end
         File.open(path, 'w') {|f| f.print(highlighted_code) }
       end


### PR DESCRIPTION
Sometimes I make multiple edits to files and then when I try to `rake generate` my site I get a pygments parse error but I don't know where the file is. This will dump the code from the page that is causing the error to the stdout so the user can see which file is causing the problem and go into the file to find where the error is and repair it. I have scraped many websites using Jekyll because it's too cumbersome for me to back over many many posts looking for an error and moved back and forth to Wordpress because of this. Now that I know how to resolve this, I will no longer have to scrap whole posts and move from Markdown back to HTML. This will help future users too.
