### PR TITLE
add ssh_args variable to Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ require "stringex"
 # Be sure your public key is listed in your server's ~/.ssh/authorized_keys file
 ssh_user       = "user@domain.com"
 ssh_port       = "22"
+ssh_args       = ""  # Extra arguments to pass to ssh
 document_root  = "~/website.com/"
 rsync_delete   = false
 rsync_args     = ""  # Any extra arguments to pass to rsync
@@ -245,7 +246,7 @@ task :rsync do
     exclude = "--exclude-from '#{File.expand_path('./rsync-exclude')}'"
   end
   puts "## Deploying website via Rsync"
-  ok_failed system("rsync -avze 'ssh -p #{ssh_port}' #{exclude} #{rsync_args} #{"--delete" unless rsync_delete == false} #{public_dir}/ #{ssh_user}:#{document_root}")
+  ok_failed system("rsync -avze 'ssh -p #{ssh_port} #{ssh_args}' #{exclude} #{rsync_args} #{"--delete" unless rsync_delete == false} #{public_dir}/ #{ssh_user}:#{document_root}")
 end
 
 desc "deploy public directory to github pages"


### PR DESCRIPTION
Example of use case: `ssh_args="-i ~/.ssh/id_rsa_custom"` yields `ssh -i ~/.ssh/id_rsa_custom`.
